### PR TITLE
[11.0][FIX] ursa modules migration

### DIFF
--- a/ursa_crmlead/migrations/11.0.1.0.0/noupdate_changes.xml
+++ b/ursa_crmlead/migrations/11.0.1.0.0/noupdate_changes.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="crm_lead_replace_leads_email_from" model="ir.config_parameter">
+        <field name="key">crm.lead.replace.email.from</field>
+        <field name="value">True</field>
+    </record>
+
+    <function model="ir.default" name="set" id="default_lead_reply_to"
+          eval="('crm.lead', 'reply_to', 'sales@lulzbot.com')"/>
+</odoo>

--- a/ursa_crmlead/migrations/11.0.1.0.0/post-migration.py
+++ b/ursa_crmlead/migrations/11.0.1.0.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Eficent <http://www.eficent.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, 'ursa_crmlead', 'migrations/11.0.1.0.0/noupdate_changes.xml',
+    )

--- a/ursa_helpdesk/migrations/11.0.1.0.0/noupdate_changes.xml
+++ b/ursa_helpdesk/migrations/11.0.1.0.0/noupdate_changes.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="crm_helpdesk_replace_email_from" model="ir.config_parameter">
+        <field name="key">crm.helpdesk.replace.email.from</field>
+        <field name="value">True</field>
+    </record>
+
+    <function model="ir.default" name="set" id="default_helpdesk_reply_to"
+          eval="('crm.helpdesk', 'reply_to', 'support@lulzbot.com')"/>
+</odoo>

--- a/ursa_helpdesk/migrations/11.0.1.0.0/post-migration.py
+++ b/ursa_helpdesk/migrations/11.0.1.0.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Eficent <http://www.eficent.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, 'ursa_helpdesk', 'migrations/11.0.1.0.0/noupdate_changes.xml',
+    )


### PR DESCRIPTION
The `ir.values` in v10 and v9 of ursa modules were wrong, so in the v11 migration to `ir.default`, they don't pass correctly.

The solution is to force to create new values.