### PR TITLE
[11.0][ADD] ddmrp_dlt_purchase_manual

### DIFF
--- a/ddmrp_dlt_purchase_manual/README.rst
+++ b/ddmrp_dlt_purchase_manual/README.rst
@@ -1,0 +1,23 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================
+DDMRP DLT Purchase Manual
+=========================
+
+With this module the purchasing Lead Time for purchased buffers is obtained
+from the buffer *Lead Time* field instead from the product supplier
+information.
+
+Credits
+=======
+
+The initial development of this module has been financially supported by:
+
+* Aleph Objects, Inc.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>

--- a/ddmrp_dlt_purchase_manual/__init__.py
+++ b/ddmrp_dlt_purchase_manual/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ddmrp_dlt_purchase_manual/__manifest__.py
+++ b/ddmrp_dlt_purchase_manual/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Aleph Objects, Inc. (https://www.alephobjects.com)
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "DDMRP DLT Purchase Manual",
+    "version": "11.0.1.0.0",
+    "author": "Eficent Business and IT Consulting Services S.L.",
+    "website": "http://www.eficent.com",
+    "category": "Warehouse Management",
+    "depends": [
+        "ddmrp",
+    ],
+    "data": [],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/ddmrp_dlt_purchase_manual/models/__init__.py
+++ b/ddmrp_dlt_purchase_manual/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_warehouse_orderpoint

--- a/ddmrp_dlt_purchase_manual/models/stock_warehouse_orderpoint.py
+++ b/ddmrp_dlt_purchase_manual/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Aleph Objects, Inc. (https://www.alephobjects.com)
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class Buffer(models.Model):
+    _inherit = "stock.warehouse.orderpoint"
+
+    @api.depends('lead_days', 'product_id.seller_ids.delay')
+    def _compute_dlt(self):
+        purchased_buffers = self.filtered(
+            lambda r: r.buffer_profile_id.item_type == 'purchased')
+        for rec in purchased_buffers:
+            rec.dlt = rec.lead_days
+        super(Buffer, self - purchased_buffers)._compute_dlt()

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -15,6 +15,11 @@ crm https://github.com/Eficent/crm.git 11.0-mig-crm_helpdesk
 stock-logistics-warehouse https://github.com/OCA/stock-logistics-warehouse.git 11.0
 # module: ao_mail
 social https://github.com/OCA/social.git 11.0
+# module: ddmrp_dlt_purchase_manual
+ddmrp https://github.com/OCA/ddmrp.git 11.0
+manufacture https://github.com/OCA/manufacture.git 11.0
+web https://github.com/OCA/web.git 11.0
+server-tools https://github.com/OCA/server-tools.git 11.0
 # module: rma_crm_helpdesk
 stock-rma https://github.com/Eficent/stock-rma.git 11.0
 # until mail_activity_done gets merged:


### PR DESCRIPTION
With this module the purchasing Lead Time for purchased buffers is obtained
from the buffer *Lead Time* field instead from the product supplier
information.

cc @jbeficent 