### PR TITLE
[11.0][FIX] usa_localization: delete rml_paper_format field

### DIFF
--- a/usa_localization/data/base_data.xml
+++ b/usa_localization/data/base_data.xml
@@ -16,7 +16,6 @@
         
     <record id="base.main_company" model="res.company">
         <field name="currency_id" ref="base.USD"/>
-        <field name="paper_format">us_letter</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
The field rml_paper_format is deleted in https://github.com/odoo/odoo/commit/3425752eaca236c1e4b4d616aa49b3faa6cfd957#diff-a7f3fa198325d9e70aede8b550b93b43L152.

As you can see in https://github.com/OCA/OpenUpgrade/blob/11.0/odoo/addons/base/migrations/11.0.1.3/openupgrade_analysis_work.txt#L160, it's a `nothing to do`.