### PR TITLE
[10.0][FIX] usa_localization: paper_format -> rml_paper_format

### DIFF
--- a/usa_localization/data/base_data.xml
+++ b/usa_localization/data/base_data.xml
@@ -16,7 +16,7 @@
         
     <record id="base.main_company" model="res.company">
         <field name="currency_id" ref="base.USD"/>
-        <field name="paper_format">us_letter</field>
+        <field name="rml_paper_format">us_letter</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
As you can see in https://github.com/OCA/OpenUpgrade/blob/8.0/openerp/addons/base/migrations/8.0.1.3/openupgrade_analysis_work.txt#L111, it was automatically renamed in v8.