### PR TITLE
[IMP] Datetime to Date field in stock valuation wizard

### DIFF
--- a/ao_stock/__init__.py
+++ b/ao_stock/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/ao_stock/__manifest__.py
+++ b/ao_stock/__manifest__.py
@@ -16,6 +16,7 @@
         "views/report_stockpicking_operations.xml",
         "views/report_stockinventory.xml",
         "views/report_deliveryslip.xml",
+        "wizard/stock_quantity_history.xml",
     ],
     "license": "AGPL-3",
     'installable': True,

--- a/ao_stock/wizard/__init__.py
+++ b/ao_stock/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_quantity_history

--- a/ao_stock/wizard/stock_quantity_history.py
+++ b/ao_stock/wizard/stock_quantity_history.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+from datetime import datetime
+
+
+class StockQuantityHistory(models.TransientModel):
+    _inherit = 'stock.quantity.history'
+
+    date_wizard = fields.Date(
+        'Inventory at Date',
+        help="Choose a date to get the inventory at that date",
+        default=fields.Date.context_today
+    )
+
+    def open_table(self):
+        self.ensure_one()
+        if self.compute_at_date:
+            self.date = datetime.strptime(
+                "%s %s" % (self.date_wizard, "23:59:59.9999"),
+                '%Y-%m-%d %H:%M:%S.%f')
+        res = super(StockQuantityHistory, self).open_table()
+        res.update({
+            'context': dict(self.env.context, to_date=self.date)
+        })
+        return res

--- a/ao_stock/wizard/stock_quantity_history.xml
+++ b/ao_stock/wizard/stock_quantity_history.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_stock_quantity_history" model="ir.ui.view">
+        <field name="name">Inventory Report</field>
+        <field name="model">stock.quantity.history</field>
+        <field name="inherit_id" ref="stock.view_stock_quantity_history"/>
+        <field name="arch" type="xml">
+            <field name="date" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="date" position="after">
+                <field name="date_wizard" attrs="{'invisible': [('compute_at_date', '=', 0)]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/ao_stock_account/__manifest__.py
+++ b/ao_stock_account/__manifest__.py
@@ -17,6 +17,7 @@
         'views/stock_account_views.xml',
         'views/product_product_views.xml',
         'views/stock_quant_views.xml',
+        'wizards/stock_quantity_history_views.xml',
     ],
     'installable': True,
 }

--- a/ao_stock_account/wizards/stock_quantity_history.py
+++ b/ao_stock_account/wizards/stock_quantity_history.py
@@ -3,14 +3,23 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
+from datetime import datetime
 
 
 class StockQuantityHistory(models.TransientModel):
     _inherit = 'stock.quantity.history'
 
     def open_table(self):
+        self.ensure_one()
+        if self.compute_at_date:
+            self.date = datetime.strptime(
+                "%s %s" % (self.date_wizard, "23:59:59.9999"),
+                '%Y-%m-%d %H:%M:%S.%f')
         action = super(StockQuantityHistory, self).open_table()
         if self.compute_at_date:
+            action.update({
+                'context': dict(self.env.context, to_date=self.date)
+            })
             tree_view_id = self.env.ref(
                 'ao_stock_account.view_stock_product_tree2').id
             action['views'][0] = (tree_view_id, 'tree')

--- a/ao_stock_account/wizards/stock_quantity_history_views.xml
+++ b/ao_stock_account/wizards/stock_quantity_history_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_stock_quantity_history" model="ir.ui.view">
+        <field name="name">Valuation Report</field>
+        <field name="model">stock.quantity.history</field>
+        <field name="inherit_id" ref="stock_account.view_stock_quantity_history"/>
+        <field name="arch" type="xml">
+            <field name="date" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="date" position="after">
+                <field name="date_wizard" attrs="{'invisible': [('compute_at_date', '=', 0)]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR changes the Datetime field in stock valuation report wizard to a Date field and computes the report for the specified date (date + 23:59:59.999)

Related to: https://projects.alephobjects.com/work_packages/20871