### PR TITLE
[11.0] Sales managers can add and remove users from sales channel

### DIFF
--- a/ao_crm/README.rst
+++ b/ao_crm/README.rst
@@ -11,6 +11,7 @@ This module contains customizations specific to Aleph Objects.
 * Sort lead by ID (descending).
 * Add three fields to CRM lead to improve the CRM capabilities.
 * Add new form view for users to have the same abilities on the lead/opportunity pipeline as they have in the regular pipeline
+* Allow Sales Managers to add users to Sales Channel.
 
 Credits
 =======

--- a/ao_crm/__manifest__.py
+++ b/ao_crm/__manifest__.py
@@ -3,12 +3,13 @@
 
 {
     "name": "AO-specific customizations on CRM",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "http://www.eficent.com",
     "category": "CRM",
     "depends": ["crm",
-                "crm_stage_type"],
+                "crm_stage_type",
+                "sales_team"],
     "data": [
         'views/crm_lead_views.xml',
         'views/crm_stage_views.xml',

--- a/ao_crm/models/crm_team.py
+++ b/ao_crm/models/crm_team.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CrmTeam(models.Model):
@@ -9,3 +9,12 @@ class CrmTeam(models.Model):
 
     stage_ids = fields.Many2many('crm.stage', 'crm_team_stage_rel',
                                  'team_id', 'stage_id', 'Stages')
+
+    @api.multi
+    def write(self, vals):
+        if vals.get('member_ids') and self.env.user.has_group(
+                'sales_team.group_sale_manager'):
+            result = super(CrmTeam, self.sudo()).write(vals)
+        else:
+            result = super(CrmTeam, self).write(vals)
+        return result


### PR DESCRIPTION
This is a temporary code that allow sales managers to write as sudo if this only implies member_ids on crm team sales channel.
CC @jbeficent 