### PR TITLE
[11.0] ao_stock: replace gp name for route name

### DIFF
--- a/ao_stock/README.rst
+++ b/ao_stock/README.rst
@@ -20,6 +20,8 @@ This module contains customizations specific to Aleph Objects.
   line so it could be filled up by pencil.
 * Delivery Slip report sorted by source location.
 * Able to access picking from stock move form view.
+* Change generic PG/XXXXX for route name on origin due to module
+  procurement_auto_create_group
 
 Credits
 =======

--- a/ao_stock/__manifest__.py
+++ b/ao_stock/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "AO-specific customizations on stock",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "http://www.eficent.com",
     "category": "Warehouse Management",

--- a/ao_stock/models/__init__.py
+++ b/ao_stock/models/__init__.py
@@ -1,2 +1,3 @@
+from . import procurement_group
 from . import stock_move
 from . import stock_picking

--- a/ao_stock/models/procurement_group.py
+++ b/ao_stock/models/procurement_group.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import re
+from odoo import api, models
+
+PG_PATTERN = r"^PG/[0-9]+"
+
+
+class ProcurementGroup(models.Model):
+    _inherit = "procurement.group"
+
+    @api.model
+    def run(self, product_id, product_qty, product_uom, location_id, name,
+            origin, values):
+        if ('orderpoint_id' in values or 'orderpoint_ids' in values) and \
+                name not in origin:
+            if re.match(PG_PATTERN, origin):
+                origin = re.sub(PG_PATTERN, name, origin)
+        return super(ProcurementGroup, self).run(product_id, product_qty,
+                                                 product_uom, location_id,
+                                                 name, origin, values)


### PR DESCRIPTION
 replace procurement group name for route name in orderpoint moves, because of module procurement_auto_create_group