### PR TITLE
[11.0][ADD] ao_security module. Fixes:  #21315

### DIFF
--- a/ao_security/README.rst
+++ b/ao_security/README.rst
@@ -8,7 +8,6 @@ AO-specific customizations for Security
 
 This module contains customizations specific to Aleph Objects.
 
-* Remove Write, Create and Unlink permissions to models Product and Product Template for everyone except Product Maintainer
 * Add UoM Maintainer group which will be the only one with CRUD permissions to UoM and UoM Category
 * Add Stock Maintainer group which will be the only one with CRUD permission to Warehouse, Location, Location route, Procurement rule and Picking Type
 * Add BoM Maintainer group which will be the only one with CRUD permissions to BoM and BoM Lines

--- a/ao_security/README.rst
+++ b/ao_security/README.rst
@@ -1,0 +1,24 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=======================================
+AO-specific customizations for Security
+=======================================
+
+This module contains customizations specific to Aleph Objects.
+
+* Remove Write, Create and Unlink permissions to models Product and Product Template for everyone except Product Maintainer
+* Add UoM Maintainer group which will be the only one with CRUD permissions to UoM and UoM Category
+* Add Stock Maintainer group which will be the only one with CRUD permission to Warehouse, Location, Location route, Procurement rule and Picking Type
+* Add BoM Maintainer group which will be the only one with CRUD permissions to BoM and BoM Lines
+
+All other groups have been left with only Reading capabilities to the previous models
+
+Credits
+=======
+
+Contributors
+------------
+
+* Adria Gil Sorribes <adria.gil@eficent.com>

--- a/ao_security/__init__.py
+++ b/ao_security/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ao_security/__manifest__.py
+++ b/ao_security/__manifest__.py
@@ -10,7 +10,7 @@
     'license': 'AGPL-3',
     'author': 'Eficent Business and IT Consulting Services S.L.',
     'website': 'http://www.eficent.com',
-    'depends': ['base'],
+    'depends': ['sale_stock', 'purchase', 'mrp', 'hr_expense'],
     'data': [
         "security/ao_security_groups.xml",
         "security/ir.model.access.csv",

--- a/ao_security/__manifest__.py
+++ b/ao_security/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Aleph Objects, Inc. (https://www.alephobjects.com)
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Ao Security',
+    'description': """
+        Manage security rules for different models""",
+    'version': '11.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Eficent Business and IT Consulting Services S.L.',
+    'website': 'http://www.eficent.com',
+    'depends': ['base'],
+    'data': [
+        "security/ao_security_groups.xml",
+        "security/ir.model.access.csv",
+    ],
+}

--- a/ao_security/models/__init__.py
+++ b/ao_security/models/__init__.py
@@ -1,0 +1,3 @@
+from . import mrp_bom
+from . import product_uom
+from . import stock

--- a/ao_security/models/mrp_bom.py
+++ b/ao_security/models/mrp_bom.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, SUPERUSER_ID, _
+from odoo.exceptions import ValidationError
+
+
+class MrpBom(models.Model):
+    _inherit = 'mrp.bom'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_bom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only BoM Maintainers can create Bills of Materials."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_bom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only BoM Maintainers can modify fields in Bill of Materials "
+                "model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_bom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only BoM Maintainers can delete Bills of Materials."))
+        super().unlink()

--- a/ao_security/models/product_uom.py
+++ b/ao_security/models/product_uom.py
@@ -1,0 +1,69 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, SUPERUSER_ID, _
+from odoo.exceptions import ValidationError
+
+
+class ProductUoM(models.Model):
+    _inherit = 'product.uom'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can create Units of Measure."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can modify fields in Units of Measure "
+                "model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can delete Units of Measure."))
+        super().unlink()
+
+
+class ProductUoMCategory(models.Model):
+    _inherit = 'product.uom.categ'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can create UoM Categories."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can modify fields in UoM Category "
+                "model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_uom_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only UoM Maintainers can delete UoM Categories."))
+        super().unlink()

--- a/ao_security/models/stock.py
+++ b/ao_security/models/stock.py
@@ -1,0 +1,163 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, SUPERUSER_ID, _
+from odoo.exceptions import ValidationError
+
+
+class Warehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can create Warehouses."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can modify fields in Warehouse model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can delete Warehouses."))
+        super().unlink()
+
+
+class Location(models.Model):
+    _inherit = 'stock.location'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can create Locations."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can modify fields in Locations model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can delete Locations."))
+        super().unlink()
+
+
+class ProcurementRule(models.Model):
+    _inherit = 'procurement.rule'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can create Procurement Rules."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can modify fields in Procurement Rules"
+                " model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can delete Procurement Rules."))
+        super().unlink()
+
+
+class Route(models.Model):
+    _inherit = 'stock.location.route'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can create Routes."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can modify fields in Location Routes"
+                " model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can delete Routes."))
+        super().unlink()
+
+
+class PickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can create Picking Types."))
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can modify fields in Picking Types"
+                " model"))
+        super().write(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.user.has_group(
+                'ao_security.group_stock_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Stock Maintainers can delete Picking Types."))
+        super().unlink()

--- a/ao_security/security/ao_security_groups.xml
+++ b/ao_security/security/ao_security_groups.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record model="res.groups" id="group_uom_maintainer">
+        <field name="name">UoM Maintainer</field>
+    </record>
+
+    <record model="res.groups" id="group_stock_maintainer">
+        <field name="name">Stock Maintainer</field>
+    </record>
+
+    <record model="res.groups" id="group_bom_maintainer">
+        <field name="name">BoM Maintainer</field>
+    </record>
+
+</odoo>

--- a/ao_security/security/ir.model.access.csv
+++ b/ao_security/security/ir.model.access.csv
@@ -5,16 +5,12 @@ purchase.access_product_product_purchase_manager,product.product purchase_manage
 purchase.access_product_template_purchase_manager,product.template purchase_manager,product.model_product_template,purchase.group_purchase_manager,1,0,0,0
 mrp.access_product_product_mrp_manager,product.product mrp_manager,product.model_product_product,mrp.group_mrp_manager,1,0,0,0
 mrp.access_product_template_mrp_manager,product.template mrp_manager,product.model_product_template,mrp.group_mrp_manager,1,0,0,0
-point_of_sale.access_product_product_pos_manager,product.product.pos manager,product.model_product_product,point_of_sale.group_pos_manager,1,0,0,0
-point_of_sale.access_product_template_pos_manager,product.template pos manager,product.model_product_template,point_of_sale.group_pos_manager,1,0,0,0
 hr_expense.access_product_product_hr_expense_user,product.product.hr.expense.user,product.model_product_product,hr_expense.group_hr_expense_user,1,0,0,0
 hr_expense.access_product_template_hr_expense_user,product.template.hr.expense.user,product.model_product_template,hr_expense.group_hr_expense_user,1,0,0,0
 account.access_product_product_account_manager,product.product.account.manager,product.model_product_product,account.group_account_manager,1,0,0,0
 account.access_product_template_account_manager,product.template.account.manager,product.model_product_template,account.group_account_manager,1,0,0,0
 sale.access_product_product_sale_manager,product.product salemanager,product.model_product_product,sales_team.group_sale_manager,1,0,0,0
 sale.access_product_template_sale_manager,product.template salemanager,product.model_product_template,sales_team.group_sale_manager,1,0,0,0
-event_sale.access_product_product_event_manager,product.product.event.manager,product.model_product_product,event.group_event_manager,1,0,0,0
-event_sale.access_product_template_event_manager,product.template.event.manager,product.model_product_template,event.group_event_manager,1,0,0,0
 purchase.access_product_uom_categ_purchase_manager,product.uom.categ purchase_manager,product.model_product_uom_categ,purchase.group_purchase_manager,1,0,0,0
 purchase.access_product_uom_purchase_manager,product.uom purchase_manager,product.model_product_uom,purchase.group_purchase_manager,1,0,0,0
 access_product_uom_categ_maintainer,product.uom.categ uom_maintainer,product.model_product_uom_categ,group_uom_maintainer,1,1,1,1
@@ -26,7 +22,6 @@ mrp.access_product_uom_categ_mrp_manager,product.uom.categ mrp_manager,product.m
 mrp.access_product_uom_mrp_manager,product.uom mrp_manager,product.model_product_uom,mrp.group_mrp_manager,1,0,0,0
 sale.access_product_uom_categ_sale_manager,product.uom.categ salemanager,product.model_product_uom_categ,sales_team.group_sale_manager,1,0,0,0
 sale.access_product_uom_sale_manager,product.uom salemanager,product.model_product_uom,sales_team.group_sale_manager,1,0,0,0
-point_of_sale.access_product_uom_manager,product.uom manager,product.model_product_uom,point_of_sale.group_pos_manager,1,0,0,0
 access_stock_warehouse_maintainer,stock.warehouse.maintainer,stock.model_stock_warehouse,group_stock_maintainer,1,1,1,1
 access_stock_location_maintainer,stock.location.maintainer,stock.model_stock_location,group_stock_maintainer,1,1,1,1
 access_procurement_rule_maintainer,procurement_rule maintainer,stock.model_procurement_rule,group_stock_maintainer,1,1,1,1
@@ -34,7 +29,7 @@ access_stock_location_route_stock_maintainer,stock.location.route.maintainer,sto
 access_stock_picking_type_maintainer,stock.picking.type maintainer,stock.model_stock_picking_type,group_stock_maintainer,1,1,1,1
 stock.access_stock_warehouse_manager,stock.warehouse.manager,stock.model_stock_warehouse,stock.group_stock_manager,1,0,0,0
 stock.access_stock_location_manager,stock.location.manager,stock.model_stock_location,stock.group_stock_manager,1,0,0,0
-sotck.access_procurement_rule_manager,procurement_rule manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
+stock.access_procurement_rule_manager,procurement_rule manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
 stock.access_procurement_rule_stock_manager,procurement_rule stock manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
 sale_stock.access_procurement_rule_salemanager,procurement_rule salemanager,stock.model_procurement_rule,sales_team.group_sale_manager,1,0,0,0
 stock.access_procurement_rule,procurement.rule,stock.model_procurement_rule,base.group_user,1,0,0,0

--- a/ao_security/security/ir.model.access.csv
+++ b/ao_security/security/ir.model.access.csv
@@ -1,41 +1,10 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-stock.access_product_product_stock_manager,product.product stock_manager,product.model_product_product,stock.group_stock_manager,1,0,0,0
-stock.access_product_template_stock_manager,product.template stock_manager,product.model_product_template,stock.group_stock_manager,1,0,0,0
-purchase.access_product_product_purchase_manager,product.product purchase_manager,product.model_product_product,purchase.group_purchase_manager,1,0,0,0
-purchase.access_product_template_purchase_manager,product.template purchase_manager,product.model_product_template,purchase.group_purchase_manager,1,0,0,0
-mrp.access_product_product_mrp_manager,product.product mrp_manager,product.model_product_product,mrp.group_mrp_manager,1,0,0,0
-mrp.access_product_template_mrp_manager,product.template mrp_manager,product.model_product_template,mrp.group_mrp_manager,1,0,0,0
-hr_expense.access_product_product_hr_expense_user,product.product.hr.expense.user,product.model_product_product,hr_expense.group_hr_expense_user,1,0,0,0
-hr_expense.access_product_template_hr_expense_user,product.template.hr.expense.user,product.model_product_template,hr_expense.group_hr_expense_user,1,0,0,0
-account.access_product_product_account_manager,product.product.account.manager,product.model_product_product,account.group_account_manager,1,0,0,0
-account.access_product_template_account_manager,product.template.account.manager,product.model_product_template,account.group_account_manager,1,0,0,0
-sale.access_product_product_sale_manager,product.product salemanager,product.model_product_product,sales_team.group_sale_manager,1,0,0,0
-sale.access_product_template_sale_manager,product.template salemanager,product.model_product_template,sales_team.group_sale_manager,1,0,0,0
-purchase.access_product_uom_categ_purchase_manager,product.uom.categ purchase_manager,product.model_product_uom_categ,purchase.group_purchase_manager,1,0,0,0
-purchase.access_product_uom_purchase_manager,product.uom purchase_manager,product.model_product_uom,purchase.group_purchase_manager,1,0,0,0
 access_product_uom_categ_maintainer,product.uom.categ uom_maintainer,product.model_product_uom_categ,group_uom_maintainer,1,1,1,1
 access_product_uom_maintainer,product.uom uom_maintainer,product.model_product_uom,group_uom_maintainer,1,1,1,1
-stock.access_product_uom_categ_stock_manager,product.uom.categ stock_manager,product.model_product_uom_categ,stock.group_stock_manager,1,0,0,0
-stock.access_product_uom_stock_manager,product.uom stock_manager,product.model_product_uom,stock.group_stock_manager,1,0,0,0
-hr_expense.access_product_uom_hr_expense_user,product.uom.hr.expense.user,product.model_product_uom,hr_expense.group_hr_expense_user,1,0,0,0
-mrp.access_product_uom_categ_mrp_manager,product.uom.categ mrp_manager,product.model_product_uom_categ,mrp.group_mrp_manager,1,0,0,0
-mrp.access_product_uom_mrp_manager,product.uom mrp_manager,product.model_product_uom,mrp.group_mrp_manager,1,0,0,0
-sale.access_product_uom_categ_sale_manager,product.uom.categ salemanager,product.model_product_uom_categ,sales_team.group_sale_manager,1,0,0,0
-sale.access_product_uom_sale_manager,product.uom salemanager,product.model_product_uom,sales_team.group_sale_manager,1,0,0,0
 access_stock_warehouse_maintainer,stock.warehouse.maintainer,stock.model_stock_warehouse,group_stock_maintainer,1,1,1,1
 access_stock_location_maintainer,stock.location.maintainer,stock.model_stock_location,group_stock_maintainer,1,1,1,1
 access_procurement_rule_maintainer,procurement_rule maintainer,stock.model_procurement_rule,group_stock_maintainer,1,1,1,1
 access_stock_location_route_stock_maintainer,stock.location.route.maintainer,stock.model_stock_location_route,group_stock_maintainer,1,1,1,1
 access_stock_picking_type_maintainer,stock.picking.type maintainer,stock.model_stock_picking_type,group_stock_maintainer,1,1,1,1
-stock.access_stock_warehouse_manager,stock.warehouse.manager,stock.model_stock_warehouse,stock.group_stock_manager,1,0,0,0
-stock.access_stock_location_manager,stock.location.manager,stock.model_stock_location,stock.group_stock_manager,1,0,0,0
-stock.access_procurement_rule_manager,procurement_rule manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
-stock.access_procurement_rule_stock_manager,procurement_rule stock manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
-sale_stock.access_procurement_rule_salemanager,procurement_rule salemanager,stock.model_procurement_rule,sales_team.group_sale_manager,1,0,0,0
-stock.access_procurement_rule,procurement.rule,stock.model_procurement_rule,base.group_user,1,0,0,0
-stock.access_stock_location_route_stock_manager,stock.location.route,stock.model_stock_location_route,stock.group_stock_manager,1,0,0,0
-stock.access_stock_picking_type_manager,stock.picking.type manager,stock.model_stock_picking_type,stock.group_stock_manager,1,0,0,0
 access_mrp_bom_maintainer,mrp.bom.maintainer,mrp.model_mrp_bom,group_bom_maintainer,1,1,1,1
 access_mrp_bom_line_maintainer,mrp.bom.line.maintainer,mrp.model_mrp_bom_line,group_bom_maintainer,1,1,1,1
-mrp.access_mrp_bom_manager,mrp.bom.manager,mrp.model_mrp_bom,mrp.group_mrp_manager,1,0,0,0
-mrp.access_mrp_bom_line_manager,mrp.bom.line.manager,mrp.model_mrp_bom_line,mrp.group_mrp_manager,1,0,0,0

--- a/ao_security/security/ir.model.access.csv
+++ b/ao_security/security/ir.model.access.csv
@@ -1,0 +1,46 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+stock.access_product_product_stock_manager,product.product stock_manager,product.model_product_product,stock.group_stock_manager,1,0,0,0
+stock.access_product_template_stock_manager,product.template stock_manager,product.model_product_template,stock.group_stock_manager,1,0,0,0
+purchase.access_product_product_purchase_manager,product.product purchase_manager,product.model_product_product,purchase.group_purchase_manager,1,0,0,0
+purchase.access_product_template_purchase_manager,product.template purchase_manager,product.model_product_template,purchase.group_purchase_manager,1,0,0,0
+mrp.access_product_product_mrp_manager,product.product mrp_manager,product.model_product_product,mrp.group_mrp_manager,1,0,0,0
+mrp.access_product_template_mrp_manager,product.template mrp_manager,product.model_product_template,mrp.group_mrp_manager,1,0,0,0
+point_of_sale.access_product_product_pos_manager,product.product.pos manager,product.model_product_product,point_of_sale.group_pos_manager,1,0,0,0
+point_of_sale.access_product_template_pos_manager,product.template pos manager,product.model_product_template,point_of_sale.group_pos_manager,1,0,0,0
+hr_expense.access_product_product_hr_expense_user,product.product.hr.expense.user,product.model_product_product,hr_expense.group_hr_expense_user,1,0,0,0
+hr_expense.access_product_template_hr_expense_user,product.template.hr.expense.user,product.model_product_template,hr_expense.group_hr_expense_user,1,0,0,0
+account.access_product_product_account_manager,product.product.account.manager,product.model_product_product,account.group_account_manager,1,0,0,0
+account.access_product_template_account_manager,product.template.account.manager,product.model_product_template,account.group_account_manager,1,0,0,0
+sale.access_product_product_sale_manager,product.product salemanager,product.model_product_product,sales_team.group_sale_manager,1,0,0,0
+sale.access_product_template_sale_manager,product.template salemanager,product.model_product_template,sales_team.group_sale_manager,1,0,0,0
+event_sale.access_product_product_event_manager,product.product.event.manager,product.model_product_product,event.group_event_manager,1,0,0,0
+event_sale.access_product_template_event_manager,product.template.event.manager,product.model_product_template,event.group_event_manager,1,0,0,0
+purchase.access_product_uom_categ_purchase_manager,product.uom.categ purchase_manager,product.model_product_uom_categ,purchase.group_purchase_manager,1,0,0,0
+purchase.access_product_uom_purchase_manager,product.uom purchase_manager,product.model_product_uom,purchase.group_purchase_manager,1,0,0,0
+access_product_uom_categ_maintainer,product.uom.categ uom_maintainer,product.model_product_uom_categ,group_uom_maintainer,1,1,1,1
+access_product_uom_maintainer,product.uom uom_maintainer,product.model_product_uom,group_uom_maintainer,1,1,1,1
+stock.access_product_uom_categ_stock_manager,product.uom.categ stock_manager,product.model_product_uom_categ,stock.group_stock_manager,1,0,0,0
+stock.access_product_uom_stock_manager,product.uom stock_manager,product.model_product_uom,stock.group_stock_manager,1,0,0,0
+hr_expense.access_product_uom_hr_expense_user,product.uom.hr.expense.user,product.model_product_uom,hr_expense.group_hr_expense_user,1,0,0,0
+mrp.access_product_uom_categ_mrp_manager,product.uom.categ mrp_manager,product.model_product_uom_categ,mrp.group_mrp_manager,1,0,0,0
+mrp.access_product_uom_mrp_manager,product.uom mrp_manager,product.model_product_uom,mrp.group_mrp_manager,1,0,0,0
+sale.access_product_uom_categ_sale_manager,product.uom.categ salemanager,product.model_product_uom_categ,sales_team.group_sale_manager,1,0,0,0
+sale.access_product_uom_sale_manager,product.uom salemanager,product.model_product_uom,sales_team.group_sale_manager,1,0,0,0
+point_of_sale.access_product_uom_manager,product.uom manager,product.model_product_uom,point_of_sale.group_pos_manager,1,0,0,0
+access_stock_warehouse_maintainer,stock.warehouse.maintainer,stock.model_stock_warehouse,group_stock_maintainer,1,1,1,1
+access_stock_location_maintainer,stock.location.maintainer,stock.model_stock_location,group_stock_maintainer,1,1,1,1
+access_procurement_rule_maintainer,procurement_rule maintainer,stock.model_procurement_rule,group_stock_maintainer,1,1,1,1
+access_stock_location_route_stock_maintainer,stock.location.route.maintainer,stock.model_stock_location_route,group_stock_maintainer,1,1,1,1
+access_stock_picking_type_maintainer,stock.picking.type maintainer,stock.model_stock_picking_type,group_stock_maintainer,1,1,1,1
+stock.access_stock_warehouse_manager,stock.warehouse.manager,stock.model_stock_warehouse,stock.group_stock_manager,1,0,0,0
+stock.access_stock_location_manager,stock.location.manager,stock.model_stock_location,stock.group_stock_manager,1,0,0,0
+sotck.access_procurement_rule_manager,procurement_rule manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
+stock.access_procurement_rule_stock_manager,procurement_rule stock manager,stock.model_procurement_rule,stock.group_stock_manager,1,0,0,0
+sale_stock.access_procurement_rule_salemanager,procurement_rule salemanager,stock.model_procurement_rule,sales_team.group_sale_manager,1,0,0,0
+stock.access_procurement_rule,procurement.rule,stock.model_procurement_rule,base.group_user,1,0,0,0
+stock.access_stock_location_route_stock_manager,stock.location.route,stock.model_stock_location_route,stock.group_stock_manager,1,0,0,0
+stock.access_stock_picking_type_manager,stock.picking.type manager,stock.model_stock_picking_type,stock.group_stock_manager,1,0,0,0
+access_mrp_bom_maintainer,mrp.bom.maintainer,mrp.model_mrp_bom,group_bom_maintainer,1,1,1,1
+access_mrp_bom_line_maintainer,mrp.bom.line.maintainer,mrp.model_mrp_bom_line,group_bom_maintainer,1,1,1,1
+mrp.access_mrp_bom_manager,mrp.bom.manager,mrp.model_mrp_bom,mrp.group_mrp_manager,1,0,0,0
+mrp.access_mrp_bom_line_manager,mrp.bom.line.manager,mrp.model_mrp_bom_line,mrp.group_mrp_manager,1,0,0,0


### PR DESCRIPTION
This module contains customizations specific to Aleph Objects.

* Add UoM Maintainer group which will be the only one with CRUD permissions to UoM and UoM Category
* Add Stock Maintainer group which will be the only one with CRUD permission to Warehouse, Location, Location route, Procurement rule and Picking Type
* Add BoM Maintainer group which will be the only one with CRUD permissions to BoM and BoM Lines

All other groups have been left with only Reading capabilities to the previous models

cc ~ @Eficent

related with: 21315