### PR TITLE
ao_crm: [ADD] force default Conversion Action value" - Fixes 21469

### DIFF
--- a/ao_crm/README.rst
+++ b/ao_crm/README.rst
@@ -12,6 +12,7 @@ This module contains customizations specific to Aleph Objects.
 * Add three fields to CRM lead to improve the CRM capabilities.
 * Add new form view for users to have the same abilities on the lead/opportunity pipeline as they have in the regular pipeline
 * Allow Sales Managers to add users to Sales Channel.
+* Forces the field **Convertion Action** to *Convert to Opportunity* as default value when converting a lead to Opportunity even if there exist the option of merging.
 
 Credits
 =======

--- a/ao_crm/__init__.py
+++ b/ao_crm/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import wizard

--- a/ao_crm/wizard/__init__.py
+++ b/ao_crm/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import crm_lead_to_opportunity

--- a/ao_crm/wizard/crm_lead_to_opportunity.py
+++ b/ao_crm/wizard/crm_lead_to_opportunity.py
@@ -1,0 +1,15 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class Lead2OpportunityPartner(models.TransientModel):
+    _inherit = 'crm.lead2opportunity.partner'
+
+    @api.model
+    def default_get(self, fields):
+        result = super(Lead2OpportunityPartner, self).default_get(fields)
+        # Force Convert Action to be Convert to opportunity as default always
+        result['name'] = 'convert'
+        return result


### PR DESCRIPTION
Add feature that forces the field **Convertion Action** to *Convert to Opportunity* as default value when converting a lead to Opportunity even if there exist the option of merging.

Related to #21469

cc ~ @Eficent