### PR TITLE
[11.0][ADD]ao_rma customizations

### DIFF
--- a/ao_rma/README.rst
+++ b/ao_rma/README.rst
@@ -1,0 +1,17 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==================
+RMA customizations
+==================
+
+Allow to select external locations for RMAs
+
+Credits
+=======
+
+Contributors
+------------
+
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>

--- a/ao_rma/__init__.py
+++ b/ao_rma/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ao_rma/__init__.py
+++ b/ao_rma/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/ao_rma/__manifest__.py
+++ b/ao_rma/__manifest__.py
@@ -9,6 +9,7 @@
     "website": "http://www.eficent.com",
     "category": "rma",
     "depends": ["rma", "rma_account", "rma_repair", "mrp_repair_account",
+                "mrp_repair_refurbish",
                 ],
     "data": ["views/rma_operation_view.xml",
              "views/rma_order_line_view.xml",

--- a/ao_rma/__manifest__.py
+++ b/ao_rma/__manifest__.py
@@ -8,10 +8,16 @@
     "author": "Eficent",
     "website": "http://www.eficent.com",
     "category": "rma",
-    "depends": ["rma_account", "rma_repair",
+    "depends": ["rma", "rma_account", "rma_repair", "mrp_repair_account",
                 ],
     "data": ["views/rma_operation_view.xml",
-             "views/rma_order_line_view.xml"],
+             "views/rma_order_line_view.xml",
+             "wizards/rma_order_line_make_repair_view.xml",
+             ],
+    "demo": [
+        "demo/stock_data.xml",
+        "demo/rma_operation.xml",
+    ],
     "license": "AGPL-3",
     'installable': True,
 }

--- a/ao_rma/__manifest__.py
+++ b/ao_rma/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Eficent",
     "website": "http://www.eficent.com",
     "category": "rma",
-    "depends": ["rma",
+    "depends": ["rma_account", "rma_repair",
                 ],
     "data": ["views/rma_operation_view.xml",
              "views/rma_order_line_view.xml"],

--- a/ao_rma/__manifest__.py
+++ b/ao_rma/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2015-18 Eficent Business and IT Consulting Services S.L.
+# - Héctor Villarreal Ortega
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "RMA Customizations",
+    "version": "11.0.1.0.0",
+    "author": "Eficent",
+    "website": "http://www.eficent.com",
+    "category": "rma",
+    "depends": ["rma",
+                ],
+    "data": ["views/rma_operation_view.xml",
+             "views/rma_order_line_view.xml"],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/ao_rma/demo/rma_operation.xml
+++ b/ao_rma/demo/rma_operation.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="rma_operation_repair_nw" model="rma.operation">
+        <field name="name">Repair no warranty</field>
+        <field name="code">REP-NW</field>
+        <field name="receipt_policy">ordered</field>
+        <field name="delivery_policy">repair</field>
+        <field name="repair_type">received</field>
+        <field name="type">customer</field>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_warranty"/>
+        <field name="location_id" ref="ao_rma.rma_external_location"/>
+        <field name="in_route_id" ref="rma.route_rma_customer"/>
+        <field name="out_route_id" ref="rma.route_rma_customer"/>
+    </record>
+
+    <record id="rma_operation_repair_warranty" model="rma.operation">
+        <field name="name">Repair Under Warranty</field>
+        <field name="code">REP-W</field>
+        <field name="receipt_policy">ordered</field>
+        <field name="delivery_policy">repair</field>
+        <field name="repair_type">received</field>
+        <field name="type">customer</field>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_no_warranty"/>
+        <field name="location_id" ref="ao_rma.rma_external_location"/>
+        <field name="in_route_id" ref="rma.route_rma_customer"/>
+        <field name="out_route_id" ref="rma.route_rma_customer"/>
+    </record>
+
+</odoo>

--- a/ao_rma/demo/rma_operation.xml
+++ b/ao_rma/demo/rma_operation.xml
@@ -8,7 +8,7 @@
         <field name="delivery_policy">repair</field>
         <field name="repair_type">received</field>
         <field name="type">customer</field>
-        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_warranty"/>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_no_warranty"/>
         <field name="location_id" ref="ao_rma.rma_external_location"/>
         <field name="in_route_id" ref="rma.route_rma_customer"/>
         <field name="out_route_id" ref="rma.route_rma_customer"/>
@@ -21,8 +21,34 @@
         <field name="delivery_policy">repair</field>
         <field name="repair_type">received</field>
         <field name="type">customer</field>
-        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_no_warranty"/>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_warranty"/>
         <field name="location_id" ref="ao_rma.rma_external_location"/>
+        <field name="in_route_id" ref="rma.route_rma_customer"/>
+        <field name="out_route_id" ref="rma.route_rma_customer"/>
+    </record>
+
+    <record id="rma_operation_repair_internal" model="rma.operation">
+        <field name="name">Internal Repair</field>
+        <field name="code">REP-INT</field>
+        <field name="receipt_policy">no</field>
+        <field name="delivery_policy">no</field>
+        <field name="repair_type">ordered</field>
+        <field name="type">customer</field>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_internal"/>
+        <field name="location_id" ref="stock.stock_location_stock"/>
+        <field name="in_route_id" ref="rma.route_rma_customer"/>
+        <field name="out_route_id" ref="rma.route_rma_customer"/>
+    </record>
+
+    <record id="rma_operation_repair_refurbish" model="rma.operation">
+        <field name="name">Refurbish Repair</field>
+        <field name="code">REP-REF</field>
+        <field name="receipt_policy">ordered</field>
+        <field name="delivery_policy">no</field>
+        <field name="repair_type">ordered</field>
+        <field name="type">customer</field>
+        <field name="repair_type_id" ref="mrp_repair_account.mrp_repair_type_refurbish"/>
+        <field name="location_id" ref="stock.stock_location_stock"/>
         <field name="in_route_id" ref="rma.route_rma_customer"/>
         <field name="out_route_id" ref="rma.route_rma_customer"/>
     </record>

--- a/ao_rma/demo/stock_data.xml
+++ b/ao_rma/demo/stock_data.xml
@@ -62,6 +62,17 @@
         <field name="code">outgoing</field>
     </record>
 
+    <record id="picking_type_rma_cust_internal" model="stock.picking.type">
+        <field name="name">Customer → RMA Internal</field>
+        <field name="sequence_id" ref="seq_picking_rma_internal_in"/>
+        <field name="default_location_src_id" ref="stock.stock_location_customers"/>
+        <field name="default_location_dest_id"
+               ref="stock.stock_location_stock"/>
+        <field name="warehouse_id" eval="False"/>
+        <field name="code">incoming</field>
+    </record>
+
+
     <!--    PROCUREMENT RULES-->
 
     <record id="rule_rma_customer_in_pull" model="procurement.rule">
@@ -75,7 +86,6 @@
         <field name="picking_type_id" ref="ao_rma.picking_type_rma_cust_in"/>
     </record>
 
-
     <record id="rule_rma_customer_out_pull" model="procurement.rule">
         <field name="name">RMA External → Customer</field>
         <field name="action">move</field>
@@ -85,6 +95,17 @@
         <field name="procure_method">make_to_stock</field>
         <field name="route_id" ref="rma.route_rma_customer"/>
         <field name="picking_type_id" ref="ao_rma.picking_type_rma_cust_out"/>
+    </record>
+
+    <record id="rule_rma_customer_internal_pull" model="procurement.rule">
+        <field name="name">Customer → RMA Internal</field>
+        <field name="action">move</field>
+        <field name="warehouse_id" ref="stock.warehouse0"/>
+        <field name="location_src_id" ref="stock.stock_location_customers"/>
+        <field name="location_id" ref="stock.stock_location_stock"/>
+        <field name="procure_method">make_to_stock</field>
+        <field name="route_id" ref="rma.route_rma_customer"/>
+        <field name="picking_type_id" ref="ao_rma.picking_type_rma_cust_internal"/>
     </record>
 
 </odoo>

--- a/ao_rma/demo/stock_data.xml
+++ b/ao_rma/demo/stock_data.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--    LOCATION-->
+    <record id="rma_external_location" model="stock.location">
+        <field name="name">RMA External Location</field>
+        <field name="usage">customer</field>
+        <field name="return_location" eval="True"/>
+    </record>
+
+    <!--    SEQUENCES-->
+    <record id="seq_picking_rma_external_in" model="ir.sequence">
+        <field name="name">RMA EXT IN</field>
+        <field name="code">stock.picking</field>
+        <field name="prefix">RMA-EX-IN/</field>
+        <field name="padding">5</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+    <record id="seq_picking_rma_external_out" model="ir.sequence">
+        <field name="name">RMA EXT OUT</field>
+        <field name="code">stock.picking</field>
+        <field name="prefix">RMA-EX-OUT/</field>
+        <field name="padding">5</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+    <record id="seq_picking_rma_internal_in" model="ir.sequence">
+        <field name="name">RMA INT IN</field>
+        <field name="code">stock.picking</field>
+        <field name="prefix">RMA-INT-IN/</field>
+        <field name="padding">5</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+    <record id="seq_picking_rma_internal_out" model="ir.sequence">
+        <field name="name">RMA INT OUT</field>
+        <field name="code">stock.picking</field>
+        <field name="prefix">RMA-INT-OUT/</field>
+        <field name="padding">5</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+    <!--    PICKING TYPES-->
+    <record id="picking_type_rma_cust_in" model="stock.picking.type">
+        <field name="name">Customer → RMA EXTERNAL</field>
+        <field name="sequence_id" ref="seq_picking_rma_external_in"/>
+        <field name="default_location_src_id" ref="stock.stock_location_customers"/>
+        <field name="default_location_dest_id"
+               ref="ao_rma.rma_external_location"/>
+        <field name="warehouse_id" eval="False"/>
+        <field name="code">incoming</field>
+    </record>
+
+    <record id="picking_type_rma_cust_out" model="stock.picking.type">
+        <field name="name">RMA EXTERNAL → Customer</field>
+        <field name="sequence_id" ref="seq_picking_rma_external_out"/>
+        <field name="default_location_src_id"
+               ref="ao_rma.rma_external_location"/>
+        <field name="default_location_dest_id" ref="stock.stock_location_customers"/>
+        <field name="warehouse_id" eval="False"/>
+        <field name="code">outgoing</field>
+    </record>
+
+    <!--    PROCUREMENT RULES-->
+
+    <record id="rule_rma_customer_in_pull" model="procurement.rule">
+        <field name="name">Customer → RMA External</field>
+        <field name="action">move</field>
+        <field name="warehouse_id" ref="stock.warehouse0"/>
+        <field name="location_src_id" ref="stock.stock_location_customers"/>
+        <field name="location_id" ref="ao_rma.rma_external_location"/>
+        <field name="procure_method">make_to_stock</field>
+        <field name="route_id" ref="rma.route_rma_customer"/>
+        <field name="picking_type_id" ref="ao_rma.picking_type_rma_cust_in"/>
+    </record>
+
+
+    <record id="rule_rma_customer_out_pull" model="procurement.rule">
+        <field name="name">RMA External → Customer</field>
+        <field name="action">move</field>
+        <field name="warehouse_id" ref="stock.warehouse0"/>
+        <field name="location_src_id" ref="ao_rma.rma_external_location"/>
+        <field name="location_id" ref="stock.stock_location_customers"/>
+        <field name="procure_method">make_to_stock</field>
+        <field name="route_id" ref="rma.route_rma_customer"/>
+        <field name="picking_type_id" ref="ao_rma.picking_type_rma_cust_out"/>
+    </record>
+
+</odoo>

--- a/ao_rma/models/__init__.py
+++ b/ao_rma/models/__init__.py
@@ -1,0 +1,2 @@
+from . import rma_order
+from . import rma_order_line

--- a/ao_rma/models/__init__.py
+++ b/ao_rma/models/__init__.py
@@ -1,2 +1,3 @@
 from . import rma_order
 from . import rma_order_line
+from . import rma_operation

--- a/ao_rma/models/rma_operation.py
+++ b/ao_rma/models/rma_operation.py
@@ -1,0 +1,10 @@
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import fields, models
+
+
+class RmaOperation(models.Model):
+    _inherit = 'rma.operation'
+
+    repair_type_id = fields.Many2one('mrp.repair.type')

--- a/ao_rma/models/rma_order.py
+++ b/ao_rma/models/rma_order.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, fields, models, _
+
+
+class RmaOrde(models.Model):
+    _inherit = "rma.order"
+
+    @api.multi
+    def _compute_in_shipment_count(self):
+        for rec in self:
+            picking_ids = []
+            for line in rec.rma_line_ids:
+                for move in line.move_ids:
+                    if move.location_dest_id.usage == 'internal' or \
+                            move.location_dest_id.return_location:
+                        picking_ids.append(move.picking_id.id)
+                    else:
+                        if line.customer_to_supplier:
+                            picking_ids.append(move.picking_id.id)
+                shipments = list(set(picking_ids))
+                line.in_shipment_count = len(shipments)
+
+    @api.multi
+    def _compute_out_shipment_count(self):
+        picking_ids = []
+        for rec in self:
+            for line in rec.rma_line_ids:
+                for move in line.move_ids:
+                    if move.location_dest_id.usage in ('supplier', 'customer') \
+                            and not move.location_dest_id.return_location:
+                        if not line.customer_to_supplier:
+                            picking_ids.append(move.picking_id.id)
+                shipments = list(set(picking_ids))
+                line.out_shipment_count = len(shipments)

--- a/ao_rma/models/rma_order.py
+++ b/ao_rma/models/rma_order.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import api, fields, models, _
+from odoo import api, models
 
 
-class RmaOrde(models.Model):
+class RmaOrder(models.Model):
     _inherit = "rma.order"
 
     @api.multi
@@ -28,9 +28,57 @@ class RmaOrde(models.Model):
         for rec in self:
             for line in rec.rma_line_ids:
                 for move in line.move_ids:
-                    if move.location_dest_id.usage in ('supplier', 'customer') \
+                    if move.location_dest_id.usage in (
+                            'supplier', 'customer') \
                             and not move.location_dest_id.return_location:
                         if not line.customer_to_supplier:
                             picking_ids.append(move.picking_id.id)
                 shipments = list(set(picking_ids))
                 line.out_shipment_count = len(shipments)
+
+    @api.multi
+    def action_view_in_shipments(self):
+        action = self.env.ref('stock.action_picking_tree_all')
+        result = action.read()[0]
+        picking_ids = []
+        for line in self.rma_line_ids:
+            for move in line.move_ids:
+                if move.location_dest_id.usage == 'internal' or \
+                        move.location_dest_id.return_location:
+                    picking_ids.append(move.picking_id.id)
+                else:
+                    if line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+        if picking_ids:
+            shipments = list(set(picking_ids))
+            # choose the view_mode accordingly
+            if len(shipments) > 1:
+                result['domain'] = [('id', 'in', shipments)]
+            else:
+                res = self.env.ref('stock.view_picking_form', False)
+                result['views'] = [(res and res.id or False, 'form')]
+                result['res_id'] = shipments[0]
+        return result
+
+    @api.multi
+    def action_view_out_shipments(self):
+        action = self.env.ref('stock.action_picking_tree_all')
+        result = action.read()[0]
+        picking_ids = []
+        for line in self.rma_line_ids:
+            for move in line.move_ids:
+                if move.location_dest_id.usage in (
+                        'supplier', 'customer') \
+                        and not move.location_dest_id.return_location:
+                    if not line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+        if picking_ids:
+            shipments = list(set(picking_ids))
+            # choose the view_mode accordingly
+            if len(shipments) != 1:
+                result['domain'] = [('id', 'in', shipments)]
+            else:
+                res = self.env.ref('stock.view_picking_form', False)
+                result['views'] = [(res and res.id or False, 'form')]
+                result['res_id'] = shipments[0]
+        return result

--- a/ao_rma/models/rma_order_line.py
+++ b/ao_rma/models/rma_order_line.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, fields, models, _
+
+
+class RmaOrderLine(models.Model):
+    _inherit = "rma.order.line"
+
+    @api.multi
+    def _compute_in_shipment_count(self):
+        for line in self:
+            picking_ids = []
+            for move in line.move_ids:
+                if move.location_dest_id.usage == 'internal' or \
+                        move.location_dest_id.return_location:
+                    picking_ids.append(move.picking_id.id)
+                else:
+                    if line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+            shipments = list(set(picking_ids))
+            line.in_shipment_count = len(shipments)
+
+    @api.multi
+    def _compute_out_shipment_count(self):
+        picking_ids = []
+        for line in self:
+            for move in line.move_ids:
+                if move.location_dest_id.usage in ('supplier', 'customer') \
+                        and not move.location_dest_id.return_location:
+                    if not line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+            shipments = list(set(picking_ids))
+            line.out_shipment_count = len(shipments)

--- a/ao_rma/models/rma_order_line.py
+++ b/ao_rma/models/rma_order_line.py
@@ -115,7 +115,7 @@ class RmaOrderLine(models.Model):
                         op(m.location_id.usage,
                            rec.type)
                         and not m.location_dest_id.return_location or
-                        m.location_dest_id.return_location))
+                        m.location_id.return_location))
             for move in moves:
                 qty += product_obj._compute_quantity(
                     move.product_uom_qty, rec.uom_id)

--- a/ao_rma/models/rma_order_line.py
+++ b/ao_rma/models/rma_order_line.py
@@ -1,11 +1,19 @@
 # Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
+import operator
+ops = {'=': operator.eq,
+       '!=': operator.ne}
 
 
 class RmaOrderLine(models.Model):
     _inherit = "rma.order.line"
+
+    in_shipment_count = fields.Integer(compute='_compute_in_shipment_count',
+                                       string='# of Shipments')
+    out_shipment_count = fields.Integer(compute='_compute_out_shipment_count',
+                                        string='# of Deliveries')
 
     @api.multi
     def _compute_in_shipment_count(self):
@@ -32,3 +40,83 @@ class RmaOrderLine(models.Model):
                         picking_ids.append(move.picking_id.id)
             shipments = list(set(picking_ids))
             line.out_shipment_count = len(shipments)
+
+    @api.multi
+    def action_view_in_shipments(self):
+
+        action = self.env.ref('stock.action_picking_tree_all')
+        result = action.read()[0]
+        picking_ids = []
+        for line in self:
+            for move in line.move_ids:
+                if move.location_dest_id.usage == 'internal' or \
+                        move.location_dest_id.return_location:
+                    picking_ids.append(move.picking_id.id)
+                else:
+                    if line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+
+        shipments = list(set(picking_ids))
+        # choose the view_mode accordingly
+        if len(shipments) != 1:
+            result['domain'] = "[('id', 'in', " + \
+                               str(shipments) + ")]"
+        elif len(shipments) == 1:
+            res = self.env.ref('stock.view_picking_form', False)
+            result['views'] = [(res and res.id or False, 'form')]
+            result['res_id'] = shipments[0]
+        return result
+
+    @api.multi
+    def action_view_out_shipments(self):
+        action = self.env.ref('stock.action_picking_tree_all')
+        result = action.read()[0]
+        picking_ids = []
+        for line in self:
+            for move in line.move_ids:
+                if move.location_dest_id.usage in ('supplier', 'customer') \
+                        and not move.location_dest_id.return_location:
+                    if not line.customer_to_supplier:
+                        picking_ids.append(move.picking_id.id)
+        shipments = list(set(picking_ids))
+        # choose the view_mode accordingly
+        if len(shipments) != 1:
+            result['domain'] = "[('id', 'in', " + \
+                               str(shipments) + ")]"
+        elif len(shipments) == 1:
+            res = self.env.ref('stock.view_picking_form', False)
+            result['views'] = [(res and res.id or False, 'form')]
+            result['res_id'] = shipments[0]
+        return result
+
+    @api.onchange('operation_id')
+    def _onchange_operation_id(self):
+        result = super(RmaOrderLine, self)._onchange_operation_id()
+        self.under_warranty = self.operation_id.repair_type_id.under_warranty
+        return result
+
+    @api.multi
+    def _get_rma_move_qty(self, states, direction='in'):
+        for rec in self:
+            product_obj = self.env['product.uom']
+            qty = 0.0
+            if direction == 'in':
+                op = ops['=']
+                moves = rec.move_ids.filtered(
+                    lambda m: m.state in states and (
+                        op(m.location_id.usage,
+                           rec.type)
+                        and not m.location_id.return_location or
+                        m.location_dest_id.return_location))
+            else:
+                op = ops['!=']
+                moves = rec.move_ids.filtered(
+                    lambda m: m.state in states and (
+                        op(m.location_id.usage,
+                           rec.type)
+                        and not m.location_dest_id.return_location or
+                        m.location_dest_id.return_location))
+            for move in moves:
+                qty += product_obj._compute_quantity(
+                    move.product_uom_qty, rec.uom_id)
+            return qty

--- a/ao_rma/tests/__init__.py
+++ b/ao_rma/tests/__init__.py
@@ -1,0 +1,2 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+from . import test_ao_rma

--- a/ao_rma/tests/test_ao_rma.py
+++ b/ao_rma/tests/test_ao_rma.py
@@ -1,0 +1,29 @@
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from openerp.addons.rma.tests import test_rma
+from openerp.exceptions import ValidationError
+
+
+class TestRma(test_rma.TestRma):
+    """ Test the routes and the quantities """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRma, cls).setUpClass()
+
+    def test_10_rma_location_out_of_the_company(cls):
+        """tests computes when receiving out of the company"""
+        wizard = cls.rma_make_picking.with_context({
+            'active_ids': cls.rma_customer_id.rma_line_ids.ids,
+            'active_model': 'rma.order.line',
+            'picking_type': 'incoming',
+            'active_id': 1
+        }).create({})
+        wizard._create_picking()
+        res = cls.rma_customer_id.rma_line_ids.action_view_in_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        cls.assertEqual(len(picking), 1)
+        res = cls.rma_customer_id.rma_line_ids.action_view_out_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        cls.assertEqual(len(picking), 0)

--- a/ao_rma/tests/test_ao_rma.py
+++ b/ao_rma/tests/test_ao_rma.py
@@ -1,28 +1,100 @@
 # © 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from openerp.addons.rma.tests import test_rma
+from odoo.tests import common
 
 
-class TestRma(test_rma.TestRma):
-    """ Test AO RMA flows"""
+class TestRma(common.SavepointCase):
+    """ Test AO flows"""
 
     @classmethod
     def setUpClass(cls):
         super(TestRma, cls).setUpClass()
+        cls.rma_make_picking = cls.env['rma_make_picking.wizard']
+        cls.repair_line_obj = cls.env['mrp.repair.line']
+        cls.rma = cls.env['rma.order']
+        cls.rma_line = cls.env['rma.order.line']
+        cls.rma_op = cls.env['rma.operation']
+        cls.product_id = cls.env.ref('product.product_product_4')
+        cls.uom_unit = cls.env.ref('product.product_uom_unit')
+        cls.partner_id = cls.env.ref('base.res_partner_2')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.stock_location_repair_refurbish = cls.env.ref(
+            'mrp_repair_account.stock_location_repair_refurbish')
+        cls.customer_location = cls.env.ref(
+            'stock.stock_location_customers')
+        cls.supplier_location = cls.env.ref(
+            'stock.stock_location_suppliers')
+        cls.product_uom_id = cls.env.ref('product.product_uom_unit')
         cls.rma_external_location = cls.env.ref(
             'ao_rma.rma_external_location')
+        cls.stock_location_customers = cls.env.ref(
+            'stock.stock_location_customers')
         cls.wiz_make_picking = cls.env['rma_make_picking.wizard']
         cls.operation_nw = cls.env.ref('ao_rma.rma_operation_repair_nw')
         cls.operation_warranty = cls.env.ref(
             'ao_rma.rma_operation_repair_warranty')
+        cls.operation_int = cls.env.ref('ao_rma.rma_operation_repair_internal')
+        cls.operation_ref = cls.env.ref('ao_rma.rma_operation_repair_refurbish')
         cls.rma_make_repair_wiz = cls.env['rma.order.line.make.repair']
         cls.repair_team = cls.env.ref(
             'mrp_repair_account.mrp_repair_team_dep1')
         cls.repair_type = cls.env.ref(
             'mrp_repair_account.mrp_repair_type_no_warranty')
         cls.aml_obj = cls.env['account.move.line']
+        cls.acc_type_model = cls.env['account.account.type']
         cls.move_obj = cls.env['stock.move']
+        cls.product_obj = cls.env['product.product']
+        cls.refurbish_product = cls.product_obj.create({
+            'name': 'Refurbished Awesome Screen',
+            'type': 'product',
+        })
+        cls.refurbish_product.product_tmpl_id.standard_price = 21
+        cls.refurbish_product.categ_id.property_valuation = 'real_time'
+
+        cls.product1 = cls.product_obj.create({
+            'name': 'Awesome Screen',
+            'type': 'product',
+            'refurbish_product_id': cls.refurbish_product.id,
+        })
+        cls.product1.product_tmpl_id.standard_price = 10
+        cls.product1.categ_id.property_valuation = 'real_time'
+        cls.material = cls.product_obj.create({
+            'name': 'Materials',
+            'type': 'product',
+        })
+
+
+        cls.material.product_tmpl_id.standard_price = 10
+        cls.material.categ_id.property_valuation = 'real_time'
+        cls.company = cls.env.ref('base.main_company')
+        a_name = 'expense'
+        a_type = 'other'
+        acc_type = cls._create_account_type(cls, a_name, a_type)
+        name = 'Cost of Goods Sold'
+        code = 'cogs'
+        cls.account_cogs = cls._create_account(cls, acc_type, name, code,
+                                               cls.company)
+        cls.product1.property_stock_account_output = cls.account_cogs.id
+        cls.refurbish_product.property_stock_account_output = \
+            cls.account_cogs.id
+
+    def _create_account_type(cls, name, a_type):
+        acc_type = cls.acc_type_model.create({
+            'name': name,
+            'type': a_type
+        })
+        return acc_type
+
+    def _create_account(cls, acc_type, name, code, company):
+        """Create an account."""
+        account = cls.env['account.account'].create({
+            'name': name,
+            'code': code,
+            'user_type_id': acc_type.id,
+            'company_id': company.id
+        })
+        return account
 
     def create_customer_rma(cls, partner, product, operation):
         vals = {'partner_id': partner.id,
@@ -68,6 +140,7 @@ class TestRma(test_rma.TestRma):
                                       cls.operation_warranty)
         rma._onchange_operation_id()
         cls.assertEqual(rma.repair_type, 'received')
+        cls.assertEqual(rma.delivery_policy, 'repair')
         rma.action_rma_approve()
         wizard = cls.wiz_make_picking.with_context({
             'active_ids': rma.id,
@@ -116,7 +189,6 @@ class TestRma(test_rma.TestRma):
         repair.action_repair_ready()
         repair.action_repair_start()
         repair.action_repair_end()
-
         # deliver
         cls.assertEqual(rma.qty_to_deliver, 1.0)
         wizard = cls.rma_make_picking.with_context({
@@ -211,3 +283,125 @@ class TestRma(test_rma.TestRma):
         # check no JE are generated
         aml = cls.aml_obj.search([('name', '=', rma.name)])
         cls.assertEqual(len(aml), 0)
+
+    def test_13_repair_internal(cls):
+        """Accounting entries for an internal reparation.
+           Everything is handled in the repair order
+        """
+
+        # create rma and receive in external location
+        rma = cls.create_customer_rma(cls.partner_id, cls.product_id,
+                                      cls.operation_int)
+        rma._onchange_operation_id()
+        cls.assertEqual(rma.repair_type, 'ordered')
+        # create repair order
+        make_repair = cls.rma_make_repair_wiz.with_context({
+            'customer': True,
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+        }).create({
+            'description': 'Test internal',
+        })
+        make_repair.make_repair_order()
+        repair = rma.repair_ids
+        rma.repair_ids.action_repair_confirm()
+
+        cls.assertEqual(repair.location_id, cls.stock_location)
+        cls.assertEqual(repair.location_dest_id, cls.stock_location)
+
+        # check stock moves
+        moves = cls.move_obj.search([('reference', '=', rma.name)])
+        cls.assertEqual(len(moves), 0)
+
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)
+
+        # end repair
+        repair.onchange_type_id()
+        repair.onchange_team_id()
+        repair.action_repair_ready()
+        repair.action_repair_start()
+        repair.action_repair_end()
+
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)
+
+    def test_14_repair_refursbish(cls):
+        """Accounting entries for return and refurbish.
+           The repair is performed inside the company
+        """
+
+        # create rma and receive in external location
+        rma = cls.create_customer_rma(cls.partner_id, cls.product1,
+                                      cls.operation_ref)
+        rma._onchange_operation_id()
+        cls.assertEqual(rma.repair_type, 'ordered')
+        rma.action_rma_approve()
+        wizard = cls.wiz_make_picking.with_context({
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+            'picking_type': 'incoming',
+            'active_id': rma.id
+        }).create({})
+        wizard._create_picking()
+        res = rma.action_view_in_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        picking.move_lines.write({'quantity_done': 1.0})
+        picking.button_validate()
+        cls.assertEqual(picking.state, 'done')
+
+        # check incoming shipment created JE
+        aml = cls.aml_obj.search([('rma_line_id', '=', rma.id)])
+        cls.assertEqual(len(aml), 1)
+        amlr = aml.filtered(lambda a: a.account_id == cls.account_cogs)
+        cls.assertEqual(sum(amlr.mapped('credit')), 10)
+
+        # create repair order
+        make_repair = cls.rma_make_repair_wiz.with_context({
+            'customer': True,
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+        }).create({
+            'description': 'Test refursbish',
+        })
+        make_repair.make_repair_order()
+        repair = rma.repair_ids
+        line = cls.repair_line_obj.create({
+            'name': 'consume stuff to repair',
+            'repair_id': repair.id,
+            'type': 'add',
+            'product_id': cls.material.id,
+            'product_uom': cls.material.uom_id.id,
+            'product_uom_qty': 1.0,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.stock_location.id,
+            'price_unit': 10.0
+        })
+
+        line.onchange_product_id()
+        repair.onchange_type_id()
+        repair.onchange_team_id()
+        repair._onchange_to_refurbish()
+        cls.assertEqual(repair.location_id, cls.stock_location)
+        cls.assertEqual(
+            repair.location_dest_id, cls.stock_location_customers)
+        cls.assertTrue(repair.to_refurbish)
+
+        rma.repair_ids.action_repair_confirm()
+
+        # end repair
+        repair.action_repair_ready()
+        repair.action_repair_start()
+        repair.action_repair_end()
+
+        # check no extra JE are generated(handled by repair order)
+        aml = cls.aml_obj.search([('rma_line_id', '=', rma.id)])
+        cls.assertEqual(len(aml), 1)
+
+        # check cogs
+        aml = cls.aml_obj.search([('name', '=', repair.name)])
+        cls.assertEqual(len(aml), 10)
+        amlr = aml.filtered(lambda a: a.account_id == cls.account_cogs)
+        cls.assertEqual(sum(amlr.mapped('debit')), 10)

--- a/ao_rma/tests/test_ao_rma.py
+++ b/ao_rma/tests/test_ao_rma.py
@@ -2,28 +2,212 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
 from openerp.addons.rma.tests import test_rma
-from openerp.exceptions import ValidationError
 
 
 class TestRma(test_rma.TestRma):
-    """ Test the routes and the quantities """
+    """ Test AO RMA flows"""
 
     @classmethod
     def setUpClass(cls):
         super(TestRma, cls).setUpClass()
+        cls.rma_external_location = cls.env.ref(
+            'ao_rma.rma_external_location')
+        cls.wiz_make_picking = cls.env['rma_make_picking.wizard']
+        cls.operation_nw = cls.env.ref('ao_rma.rma_operation_repair_nw')
+        cls.operation_warranty = cls.env.ref(
+            'ao_rma.rma_operation_repair_warranty')
+        cls.rma_make_repair_wiz = cls.env['rma.order.line.make.repair']
+        cls.repair_team = cls.env.ref(
+            'mrp_repair_account.mrp_repair_team_dep1')
+        cls.repair_type = cls.env.ref(
+            'mrp_repair_account.mrp_repair_type_no_warranty')
+        cls.aml_obj = cls.env['account.move.line']
+        cls.move_obj = cls.env['stock.move']
+
+    def create_customer_rma(cls, partner, product, operation):
+        vals = {'partner_id': partner.id,
+                'product_id': product.id,
+                'uom_id': product.uom_id.id,
+                'receipt_policy': operation.receipt_policy,
+                'delivery_policy': operation.delivery_policy,
+                'refund_policy': operation.refund_policy,
+                'in_route_id': operation.in_route_id.id,
+                'out_route_id': operation.out_route_id.id,
+                'in_warehouse_id': operation.in_warehouse_id.id,
+                'out_warehouse_id': operation.out_warehouse_id.id,
+                'location_id': operation.location_id.id,
+                'operation_id': operation.id}
+        rma = cls.rma_line.create(vals)
+        return rma
 
     def test_10_rma_location_out_of_the_company(cls):
         """tests computes when receiving out of the company"""
-        wizard = cls.rma_make_picking.with_context({
-            'active_ids': cls.rma_customer_id.rma_line_ids.ids,
+        rma = cls.create_customer_rma(cls.partner_id, cls.product_id,
+                                      cls.operation_nw)
+        rma._onchange_operation_id()
+        rma.action_rma_approve()
+        wizard = cls.wiz_make_picking.with_context({
+            'active_ids': rma.id,
             'active_model': 'rma.order.line',
             'picking_type': 'incoming',
-            'active_id': 1
+            'active_id': rma.id
         }).create({})
         wizard._create_picking()
-        res = cls.rma_customer_id.rma_line_ids.action_view_in_shipments()
+        res = rma.action_view_in_shipments()
         picking = cls.env['stock.picking'].browse(res['res_id'])
         cls.assertEqual(len(picking), 1)
-        res = cls.rma_customer_id.rma_line_ids.action_view_out_shipments()
+        res = rma.action_view_out_shipments()
         picking = cls.env['stock.picking'].browse(res['res_id'])
         cls.assertEqual(len(picking), 0)
+
+    def test_11_repair_no_warranty(cls):
+        """Accounting entries for a reparation with no warranty """
+
+        # create rma and receive in external location
+        rma = cls.create_customer_rma(cls.partner_id, cls.product_id,
+                                      cls.operation_warranty)
+        rma._onchange_operation_id()
+        cls.assertEqual(rma.repair_type, 'received')
+        rma.action_rma_approve()
+        wizard = cls.wiz_make_picking.with_context({
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+            'picking_type': 'incoming',
+            'active_id': rma.id
+        }).create({})
+        wizard._create_picking()
+        res = rma.action_view_in_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        picking.move_lines.write({'quantity_done': 1.0})
+        picking.button_validate()
+        cls.assertEqual(picking.state, 'done')
+        # create repair order
+        make_repair = cls.rma_make_repair_wiz.with_context({
+            'customer': True,
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+        }).create({
+            'description': 'Test no warranty',
+        })
+        make_repair.item_ids.team_id = cls.repair_team
+        make_repair.make_repair_order()
+        repair = rma.repair_ids
+        rma.repair_ids.action_repair_confirm()
+
+        cls.assertEqual(repair.location_id, cls.rma_external_location)
+        cls.assertEqual(repair.location_dest_id, cls.rma_external_location)
+
+        # check stock moves
+        moves = cls.move_obj.search([('reference', '=', rma.name)])
+        for m in moves:
+            cls.assertEqual(m.state, 'done')
+            cls.assertEqual(m.location_id,
+                            cls.customer_location)
+            cls.assertEqual(m.location_dest_id,
+                            cls.stock_location_rma_external)
+
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)
+
+        # end repair
+        repair.onchange_type_id()
+        repair.onchange_team_id()
+        repair.action_repair_ready()
+        repair.action_repair_start()
+        repair.action_repair_end()
+
+        # deliver
+        cls.assertEqual(rma.qty_to_deliver, 1.0)
+        wizard = cls.rma_make_picking.with_context({
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+            'picking_type': 'outgoing',
+            'active_id': rma.id
+        }).create({})
+        wizard._create_picking()
+        res = rma.action_view_out_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        picking.move_lines.write({'quantity_done': 1.0})
+        picking.button_validate()
+        cls.assertEqual(picking.state, 'done')
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)
+
+    def test_12_repair_no_warranty(cls):
+        """Accounting entries for a reparation with warranty
+           Very similar to previous test, considering remove
+        """
+
+        # create rma and receive in external location
+        rma = cls.create_customer_rma(cls.partner_id, cls.product_id,
+                                      cls.operation_nw)
+        rma._onchange_operation_id()
+        cls.assertEqual(rma.repair_type, 'received')
+        rma.action_rma_approve()
+        wizard = cls.wiz_make_picking.with_context({
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+            'picking_type': 'incoming',
+            'active_id': rma.id
+        }).create({})
+        wizard._create_picking()
+        res = rma.action_view_in_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        picking.move_lines.write({'quantity_done': 1.0})
+        picking.button_validate()
+        cls.assertEqual(picking.state, 'done')
+        # create repair order
+        make_repair = cls.rma_make_repair_wiz.with_context({
+            'customer': True,
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+        }).create({
+            'description': 'Test no warranty',
+        })
+        make_repair.item_ids.team_id = cls.repair_team
+        make_repair.make_repair_order()
+        repair = rma.repair_ids
+        rma.repair_ids.action_repair_confirm()
+
+        cls.assertEqual(repair.location_id, cls.rma_external_location)
+        cls.assertEqual(repair.location_dest_id, cls.rma_external_location)
+
+        # check stock moves
+        moves = cls.move_obj.search([('reference', '=', rma.name)])
+        for m in moves:
+            cls.assertEqual(m.state, 'done')
+            cls.assertEqual(m.location_id,
+                            cls.customer_location)
+            cls.assertEqual(m.location_dest_id,
+                            cls.stock_location_rma_external)
+
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)
+
+        # end repair
+        repair.onchange_type_id()
+        repair.onchange_team_id()
+        repair.action_repair_ready()
+        repair.action_repair_start()
+        repair.action_repair_end()
+
+        # deliver
+        cls.assertEqual(rma.qty_to_deliver, 1.0)
+        wizard = cls.rma_make_picking.with_context({
+            'active_ids': rma.id,
+            'active_model': 'rma.order.line',
+            'picking_type': 'outgoing',
+            'active_id': rma.id
+        }).create({})
+        wizard._create_picking()
+        res = rma.action_view_out_shipments()
+        picking = cls.env['stock.picking'].browse(res['res_id'])
+        picking.move_lines.write({'quantity_done': 1.0})
+        picking.button_validate()
+        cls.assertEqual(picking.state, 'done')
+        # check no JE are generated
+        aml = cls.aml_obj.search([('name', '=', rma.name)])
+        cls.assertEqual(len(aml), 0)

--- a/ao_rma/views/rma_operation_view.xml
+++ b/ao_rma/views/rma_operation_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="rma_operation_form" model="ir.ui.view">
+        <field name="name">rma.operation.form - ao</field>
+        <field name="model">rma.operation</field>
+        <field name="inherit_id" ref="rma.rma_operation_form"/>
+        <field name="arch" type="xml">
+            <field name="location_id" position="attributes">
+                <attribute name="domain"></attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/ao_rma/views/rma_operation_view.xml
+++ b/ao_rma/views/rma_operation_view.xml
@@ -12,4 +12,16 @@
         </field>
     </record>
 
+    <record id="rma_operation_repair_type_form" model="ir.ui.view">
+        <field name="name">rma.operation.form.repair.type</field>
+        <field name="model">rma.operation</field>
+        <field name="inherit_id" ref="rma.rma_operation_form"/>
+        <field name="arch" type="xml">
+            <field name="repair_type" position="after">
+                <field name="repair_type_id" attrs="{'invisible': [('repair_type','=', 'no')]}"/>
+            </field>
+        </field>
+    </record>
+
+
 </odoo>

--- a/ao_rma/views/rma_order_line_view.xml
+++ b/ao_rma/views/rma_order_line_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_rma_line_form" model="ir.ui.view">
+        <field name="name">rma.order.line.form - rma_repair</field>
+        <field name="model">rma.order.line</field>
+        <field name="inherit_id" ref="rma.view_rma_line_form"/>
+        <field name="arch" type="xml">
+            <field name="location_id" position="attributes">
+                <attribute name="domain"></attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_rma_line_button_repair_form" model="ir.ui.view">
+        <field name="name">rma.order.line.form - rma_repair</field>
+        <field name="model">rma.order.line</field>
+        <field name="inherit_id" ref="rma.view_rma_line_button_form"/>
+        <field name="arch" type="xml">
+            <field name="location_id" position="attributes">
+                <attribute name="domain"></attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/ao_rma/wizards/__init__.py
+++ b/ao_rma/wizards/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from . import rma_order_line_make_repair

--- a/ao_rma/wizards/rma_order_line_make_repair.py
+++ b/ao_rma/wizards/rma_order_line_make_repair.py
@@ -1,0 +1,32 @@
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from odoo import api, fields, models
+
+
+class RmaLineMakeRepair(models.TransientModel):
+    _inherit = "rma.order.line.make.repair"
+
+    @api.model
+    def _prepare_item(self, line):
+        res = super(RmaLineMakeRepair, self)._prepare_item(line)
+        res['type_id'] = line.operation_id.repair_type_id.id
+        res['team_id'] = line.assigned_to.mrp_repair_team_id.id
+        res['invoice_method'] = \
+            line.operation_id.repair_type_id.invoice_method or 'none'
+        return res
+
+
+class RmaLineMakeRepairItem(models.TransientModel):
+    _inherit = "rma.order.line.make.repair.item"
+
+    type_id = fields.Many2one('mrp.repair.type')
+    team_id = fields.Many2one('mrp.repair.team')
+
+    @api.model
+    def _prepare_repair_order(self, rma_line):
+        res = super(RmaLineMakeRepairItem, self)._prepare_repair_order(
+            rma_line)
+        res['type_id'] = self.type_id.id
+        res['team_id'] = self.team_id.id
+        return res

--- a/ao_rma/wizards/rma_order_line_make_repair.py
+++ b/ao_rma/wizards/rma_order_line_make_repair.py
@@ -29,4 +29,6 @@ class RmaLineMakeRepairItem(models.TransientModel):
             rma_line)
         res['type_id'] = self.type_id.id
         res['team_id'] = self.team_id.id
+        if self.type_id.to_refurbish and self.type_id.refurbish_location_id:
+            res['location_dest_id'] = self.type_id.refurbish_location_id.id
         return res

--- a/ao_rma/wizards/rma_order_line_make_repair_view.xml
+++ b/ao_rma/wizards/rma_order_line_make_repair_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+
+    <record id="view_rma_order_line_make_repair" model="ir.ui.view">
+        <field name="name">RMA Line Make Repair</field>
+        <field name="model">rma.order.line.make.repair</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="rma_repair.view_rma_order_line_make_repair"/>
+        <field name="arch" type="xml">
+             <xpath expr="//group/field[@name='item_ids']/tree/field[@name='to_refurbish']" position="before">
+                 <field name="type_id"/>
+                 <field name="team_id"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -25,3 +25,5 @@ server-tools https://github.com/OCA/server-tools.git 11.0
 stock-rma https://github.com/Eficent/stock-rma.git 11.0
 # module: ao_stock_account
 stock-logistics-reporting https://github.com/OCA/stock-logistics-reporting.git 11.0
+# module: mrp_repair_account
+mrp_repair_account https://github.com/eficent/manufacture.git 11.0-mrp_repair_account


### PR DESCRIPTION
Basically it allows to receive MRA in "customer" locations without a company and calculate the quantities accordingly. Depends on https://github.com/Eficent/manufacture/tree/11.0-mrp_repair_account

Also changes a bit the wizards that creates repair orders from RMAs in order to set proper locations on repair orders.