### PR TITLE
[11.0][FIX] ao_crm: Unable to use merge Opportunities

### DIFF
--- a/ao_crm/__manifest__.py
+++ b/ao_crm/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "AO-specific customizations on CRM",
-    "version": "11.0.1.0.2",
+    "version": "11.0.1.0.3",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "http://www.eficent.com",
     "category": "CRM",

--- a/ao_crm/wizard/crm_lead_to_opportunity.py
+++ b/ao_crm/wizard/crm_lead_to_opportunity.py
@@ -11,5 +11,6 @@ class Lead2OpportunityPartner(models.TransientModel):
     def default_get(self, fields):
         result = super(Lead2OpportunityPartner, self).default_get(fields)
         # Force Convert Action to be Convert to opportunity as default always
-        result['name'] = 'convert'
+        if 'name' in result:
+            result['name'] = 'convert'
         return result


### PR DESCRIPTION
default_get is not a reliable method on Transient models. It is used every time you trigger an action.
I added this ugly-fix in order to allow user to merge opportunities

CC @Eficent @jbeficent 