### PR TITLE
[12.0][MIG] ao_product

### DIFF
--- a/ao_product/README.rst
+++ b/ao_product/README.rst
@@ -9,6 +9,8 @@ AO-specific customizations for Products
 This module contains customizations specific to Aleph Objects.
 
 * Add button in the button box to stock moves.
+* Add *Product Maintainer* security group. This group is the only allowed
+  to create products.
 
 Credits
 =======

--- a/ao_product/README.rst
+++ b/ao_product/README.rst
@@ -12,6 +12,7 @@ This module contains customizations specific to Aleph Objects.
 * Add *Product Maintainer* security group. This group is the only allowed
   to create products.
 * Add extra Tab for Cluster products
+* Add extra Notes for Inspection Criteria on Product Card
 
 Credits
 =======

--- a/ao_product/README.rst
+++ b/ao_product/README.rst
@@ -11,6 +11,7 @@ This module contains customizations specific to Aleph Objects.
 * Add button in the button box to stock moves.
 * Add *Product Maintainer* security group. This group is the only allowed
   to create products.
+* Add extra Tab for Cluster products
 
 Credits
 =======

--- a/ao_product/README.rst
+++ b/ao_product/README.rst
@@ -1,0 +1,19 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=======================================
+AO-specific customizations for Products
+=======================================
+
+This module contains customizations specific to Aleph Objects.
+
+* Add button in the button box to stock moves.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>

--- a/ao_product/__init__.py
+++ b/ao_product/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ao_product/__manifest__.py
+++ b/ao_product/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "AO-specific customizations for Products",
-    "version": "11.0.1.1.0",
+    "version": "11.0.1.2.0",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "https://www.eficent.com",
     "category": "Product",
@@ -12,6 +12,7 @@
         "security/product_security.xml",
         "security/ir.model.access.csv",
         "views/ao_cluster_product.xml",
+        "views/ao_qc_product_template.xml",
         "views/product_product_view.xml",
         "views/product_template_view.xml",
     ],

--- a/ao_product/__manifest__.py
+++ b/ao_product/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "AO-specific customizations for Products",
+    "version": "11.0.1.0.0",
+    "author": "Eficent Business and IT Consulting Services S.L.",
+    "website": "https://www.eficent.com",
+    "category": "Product",
+    "depends": ["stock"],
+    "data": [
+        "views/product_product_view.xml",
+        "views/product_template_view.xml",
+    ],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/ao_product/__manifest__.py
+++ b/ao_product/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "AO-specific customizations for Products",
-    "version": "11.0.1.2.0",
+    "version": "12.0.1.0.0",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "https://www.eficent.com",
     "category": "Product",

--- a/ao_product/__manifest__.py
+++ b/ao_product/__manifest__.py
@@ -9,6 +9,8 @@
     "category": "Product",
     "depends": ["stock"],
     "data": [
+        "security/product_security.xml",
+        "security/ir.model.access.csv",
         "views/product_product_view.xml",
         "views/product_template_view.xml",
     ],

--- a/ao_product/__manifest__.py
+++ b/ao_product/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "AO-specific customizations for Products",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Eficent Business and IT Consulting Services S.L.",
     "website": "https://www.eficent.com",
     "category": "Product",
@@ -11,6 +11,7 @@
     "data": [
         "security/product_security.xml",
         "security/ir.model.access.csv",
+        "views/ao_cluster_product.xml",
         "views/product_product_view.xml",
         "views/product_template_view.xml",
     ],

--- a/ao_product/models/__init__.py
+++ b/ao_product/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/ao_product/models/__init__.py
+++ b/ao_product/models/__init__.py
@@ -1,2 +1,3 @@
 from . import ao_cluster_product
+from . import ao_qc_product
 from . import product

--- a/ao_product/models/__init__.py
+++ b/ao_product/models/__init__.py
@@ -1,1 +1,2 @@
+from . import ao_cluster_product
 from . import product

--- a/ao_product/models/ao_cluster_product.py
+++ b/ao_product/models/ao_cluster_product.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AoClusterProduct(models.Model):
+    _inherit = 'product.product'
+
+    bagging_amount = fields.Integer()
+    processed = fields.Boolean()
+    inserted = fields.Boolean()
+    build_reference = fields.Char()
+    print_quality = fields.Integer()
+    print_time = fields.Float()
+    color = fields.Selection([('black', 'Black'),
+                              ('green', 'Green'),
+                              ('hammer_gray', 'Hammer Gray'),
+                              ('ghost_gray', 'Ghost Gray'),
+                              ('flexy_black', 'Flexy Black'),
+                              ('flexy_green', 'Flexy Green')],)
+    is_cluster_product = fields.Boolean('Cluster Product')

--- a/ao_product/models/ao_qc_product.py
+++ b/ao_product/models/ao_qc_product.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.exceptions import ValidationError
+
+
+class AoQCProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    inspection_criteria = fields.Text(
+        string='Inspection Criteria'
+    )
+    spec_sheet = fields.Char(
+        string='Link to Spec Sheet Directory'
+    )
+
+    @api.multi
+    def write(self, vals):
+        pm_fields = ['inspection_criteria', 'spec_sheet']
+        if any([x in vals for x in pm_fields]) and not self.env.user.has_group(
+                'quality_control.group_quality_control_manager') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(_(
+                "Only Quality Control Managers can modify the following fields"
+                " in products:\n%s" % pm_fields))
+        super().write(vals)

--- a/ao_product/models/product.py
+++ b/ao_product/models/product.py
@@ -19,7 +19,7 @@ class AoProductSecurity(models.AbstractModel):
 
     @api.multi
     def write(self, vals):
-        pm_fields = ['standard_price']
+        pm_fields = ['standard_price', 'type', 'categ_id']
         if any([x in vals for x in pm_fields]) and not self.env.user.has_group(
                 'ao_product.group_product_maintainer') and \
                 self.env.uid != SUPERUSER_ID:

--- a/ao_product/models/product.py
+++ b/ao_product/models/product.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models, SUPERUSER_ID, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import ValidationError
 
 
@@ -51,3 +51,7 @@ class ProductTemplate(models.Model):
         action = self.env.ref('stock.stock_move_action').read()[0]
         action['domain'] = [('product_id.product_tmpl_id', 'in', self.ids)]
         return action
+
+    # Can Be Sold and Can Be Purchased default unchecked
+    sale_ok = fields.Boolean('Can be Sold', default=False)
+    purchase_ok = fields.Boolean('Can be Purchased', default=False)

--- a/ao_product/models/product.py
+++ b/ao_product/models/product.py
@@ -1,0 +1,26 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def action_view_stock_moves(self):
+        self.ensure_one()
+        action = self.env.ref('stock.stock_move_action').read()[0]
+        action['domain'] = [('product_id', '=', self.id)]
+        return action
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.multi
+    def action_view_stock_moves(self):
+        self.ensure_one()
+        action = self.env.ref('stock.stock_move_action').read()[0]
+        action['domain'] = [('product_id.product_tmpl_id', 'in', self.ids)]
+        return action

--- a/ao_product/models/product.py
+++ b/ao_product/models/product.py
@@ -1,11 +1,37 @@
 # Copyright 2018 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import api, models, SUPERUSER_ID
+from odoo.exceptions import ValidationError
+
+
+class AoProductSecurity(models.AbstractModel):
+    _name = 'ao.product.security'
+
+    @api.model
+    def create(self, values):
+        if not self.env.user.has_group(
+                'ao_product.group_product_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(
+                "Only Product Maintainers can create products.")
+        return super().create(values)
+
+    @api.multi
+    def write(self, vals):
+        pm_fields = ['standard_price']
+        if any([x in vals for x in pm_fields]) and not self.env.user.has_group(
+                'ao_product.group_product_maintainer') and \
+                self.env.uid != SUPERUSER_ID:
+            raise ValidationError(
+                "Only Product Maintainers can modify the following fields "
+                "in products:\n%s" % pm_fields)
+        super().write(vals)
 
 
 class ProductProduct(models.Model):
-    _inherit = 'product.product'
+    _name = 'product.product'
+    _inherit = ['product.product', 'ao.product.security']
 
     @api.multi
     def action_view_stock_moves(self):
@@ -16,7 +42,8 @@ class ProductProduct(models.Model):
 
 
 class ProductTemplate(models.Model):
-    _inherit = 'product.template'
+    _name = 'product.template'
+    _inherit = ['product.template', 'ao.product.security']
 
     @api.multi
     def action_view_stock_moves(self):

--- a/ao_product/models/product.py
+++ b/ao_product/models/product.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models, SUPERUSER_ID
+from odoo import api, models, SUPERUSER_ID, _
 from odoo.exceptions import ValidationError
 
 
@@ -13,8 +13,8 @@ class AoProductSecurity(models.AbstractModel):
         if not self.env.user.has_group(
                 'ao_product.group_product_maintainer') and \
                 self.env.uid != SUPERUSER_ID:
-            raise ValidationError(
-                "Only Product Maintainers can create products.")
+            raise ValidationError(_(
+                "Only Product Maintainers can create products."))
         return super().create(values)
 
     @api.multi
@@ -23,9 +23,9 @@ class AoProductSecurity(models.AbstractModel):
         if any([x in vals for x in pm_fields]) and not self.env.user.has_group(
                 'ao_product.group_product_maintainer') and \
                 self.env.uid != SUPERUSER_ID:
-            raise ValidationError(
+            raise ValidationError(_(
                 "Only Product Maintainers can modify the following fields "
-                "in products:\n%s" % pm_fields)
+                "in products:\n%s" % pm_fields))
         super().write(vals)
 
 

--- a/ao_product/security/ir.model.access.csv
+++ b/ao_product/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_template_maintainer,product.template.maintainer,product.model_product_template,group_product_maintainer,1,1,1,1
+access_product_product_maintainer,product.product.maintainer,product.model_product_product,group_product_maintainer,1,1,1,1
+access_product_price_history_maintainer,product.price.history maintainer,product.model_product_price_history,group_product_maintainer,1,1,1,1
+access_ir_property_maintainer,ir.property maintainer,base.model_ir_property,group_product_maintainer,1,1,1,1

--- a/ao_product/security/product_security.xml
+++ b/ao_product/security/product_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record model="res.groups" id="group_product_maintainer">
+        <field name="name">Product Maintainer</field>
+    </record>
+
+</odoo>

--- a/ao_product/tests/__init__.py
+++ b/ao_product/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ao_product

--- a/ao_product/tests/test_ao_product.py
+++ b/ao_product/tests/test_ao_product.py
@@ -1,0 +1,17 @@
+# 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+
+
+class TestAoProduct(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAoProduct, self).setUp()
+        self.product = self.env.ref('product.product_product_11')
+        self.template = self.product.product_tmpl_id
+
+    def test_01_actions(self):
+        """Call view actions to ensure there is no error."""
+        self.product.action_view_stock_moves()
+        self.template.action_view_stock_moves()

--- a/ao_product/tests/test_ao_product.py
+++ b/ao_product/tests/test_ao_product.py
@@ -2,16 +2,74 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import odoo.tests.common as common
+from odoo.exceptions import ValidationError
 
 
+@common.at_install(False)
+@common.post_install(True)
 class TestAoProduct(common.TransactionCase):
 
     def setUp(self):
         super(TestAoProduct, self).setUp()
+        self.user_obj = self.env['res.users']
+        self.product_obj = self.env['product.product']
+        self.template_obj = self.env['product.template']
+
         self.product = self.env.ref('product.product_product_11')
         self.template = self.product.product_tmpl_id
+
+        self.maintainer = self.user_obj.create({
+            'login': 'test-maintainer',
+            'name': 'Test Maintainer',
+            'email': 'test-maintainer@example.org',
+            'groups_id': [
+                (4, self.env.ref('base.group_user').id),
+                (4, self.env.ref('stock.group_stock_user').id),
+                (4, self.env.ref('ao_product.group_product_maintainer').id),
+            ]
+        })
+        self.user = self.user_obj.create({
+            'login': 'test-user',
+            'name': 'Test User',
+            'email': 'test-maintainer@example.org',
+            'groups_id': [
+                (4, self.env.ref('base.group_user').id),
+                (4, self.env.ref('stock.group_stock_manager').id),
+            ]
+        })
 
     def test_01_actions(self):
         """Call view actions to ensure there is no error."""
         self.product.action_view_stock_moves()
         self.template.action_view_stock_moves()
+
+    def test_02_security_create(self):
+        """Test who can create products."""
+        self.product_obj.sudo(self.maintainer).create({
+            'name': 'TEST Product',
+            'type': 'service',
+        })
+        with self.assertRaises(ValidationError):
+            self.product_obj.sudo(self.user).create({
+                'name': 'TEST Product',
+                'type': 'service',
+            })
+        # Admin user should overpass all rules:
+        self.product_obj.sudo().create({
+            'name': 'TEST Product',
+            'type': 'service',
+        })
+
+    def test_03_security_write(self):
+        """Test write security on products."""
+        self.product.sudo(self.maintainer).write({
+            'standard_price': 30.0,
+        })
+        with self.assertRaises(ValidationError):
+            self.product.sudo(self.user).write({
+                'standard_price': 30.0,
+            })
+        # Admin user should overpass all rules:
+        self.product_obj.sudo().write({
+            'standard_price': 30.0,
+        })

--- a/ao_product/views/ao_cluster_product.xml
+++ b/ao_product/views/ao_cluster_product.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="ao_cluster_product_form_view">
+        <field name="name">ao.cluster.product.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <div name="options" position="after">
+                <div name="ao_options">
+                    <field name="is_cluster_product"/>
+                    <label for="is_cluster_product"/>
+                </div>
+            </div>
+            <notebook position="inside">
+                 <page string="Cluster" name="cluster" attrs="{'invisible':[('is_cluster_product', '=', False)]}">
+                    <group>
+                        <group>
+                            <field name="bagging_amount"/>
+                            <field name="processed"/>
+                            <field name="inserted"/>
+                            <field name="build_reference" widget="url"/>
+                        </group>
+                        <group>
+                            <field name="print_quality"/>
+                            <field name="print_time" type="measure" widget="float_time"/>
+                            <field name="color"/>
+                        </group>
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+</odoo>

--- a/ao_product/views/ao_qc_product_template.xml
+++ b/ao_product/views/ao_qc_product_template.xml
@@ -6,14 +6,14 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <group name="description_internal" position="inside">
+                <page name="general_information" position="inside">
                     <group string="Inspection Criteria">
                         <group>
                         <field name="spec_sheet" nolabel="1" widget="url"/>
                             </group>
                         <field name="inspection_criteria" nolabel="1"/>
                     </group>
-                </group>
+                </page>
             </field>
     </record>
 

--- a/ao_product/views/ao_qc_product_template.xml
+++ b/ao_product/views/ao_qc_product_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="ao_qc_product_template_form_view" model="ir.ui.view">
+            <field name="name">ao.qc.product.template.form.view</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <group name="description_internal" position="inside">
+                    <group string="Inspection Criteria">
+                        <group>
+                        <field name="spec_sheet" nolabel="1" widget="url"/>
+                            </group>
+                        <field name="inspection_criteria" nolabel="1"/>
+                    </group>
+                </group>
+            </field>
+    </record>
+
+</odoo>

--- a/ao_product/views/product_product_view.xml
+++ b/ao_product/views/product_product_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="product_form_view_button">
+        <field name="name">product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <button name="toggle_active" position="before">
+                <button string="Stock Moves"
+                    type="object"
+                    name= "action_view_stock_moves"
+                    attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
+                    class="oe_stat_button" icon="fa-arrows-h"
+                    groups="stock.group_stock_user"/>
+            </button>
+        </field>
+    </record>
+
+</odoo>

--- a/ao_product/views/product_template_view.xml
+++ b/ao_product/views/product_template_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="product_template_form_view_button">
+        <field name="name">product.template.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <button name="toggle_active" position="before">
+                <button string="Stock Moves"
+                    type="object"
+                    name= "action_view_stock_moves"
+                    attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
+                    class="oe_stat_button" icon="fa-arrows-h"
+                    groups="stock.group_stock_user"/>
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Cluster Product specifications was defined on product.product on v11.

I'm not so sure if it could be moved to product.template as seems there are no more than one product variant per product.

What do you think @jbeficent @lreficent ?

Can we move this to product.template easily @mreficent ? 