### PR TITLE
[11.0][ADD] shipping_address_type to ao_base: #22116

### DIFF
--- a/ao_base/__manifest__.py
+++ b/ao_base/__manifest__.py
@@ -9,7 +9,10 @@
     "website": "http://www.eficent.com",
     "category": "Base",
     "depends": ["base"],
-    "data": ["security/ao_base_security.xml"],
+    "data": [
+        "security/ao_base_security.xml",
+        "views/res_partner_views.xml",
+    ],
     "license": "AGPL-3",
     'installable': True,
 }

--- a/ao_base/models/res_partner.py
+++ b/ao_base/models/res_partner.py
@@ -1,11 +1,19 @@
 # Copyright 2018 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
-class ResUsers(models.Model):
+class ResPartner(models.Model):
     _inherit = "res.partner"
+
+    shipping_address_type = fields.Selection(
+        [('residential', 'Residential'),
+         ('commercial', 'Commercial'),
+         ('educational', 'Educational'),
+         ('government', 'Government')],
+        string='Shipping Address Type'
+    )
 
     @api.onchange('state_id')
     def onchange_state(self):

--- a/ao_base/views/res_partner_views.xml
+++ b/ao_base/views/res_partner_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add shipping_address_type to res partner views -->
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority" eval="10"/>
+        <field name="arch" type="xml">
+            <field name="ref" position="after">
+                <field name="shipping_address_type"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_res_partner_filter" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+            <field name="category_id" position="after">
+                <field name="shipping_address_type"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Adds a field shipping_address_type to res_partner model. Related to [#22116](https://projects.alephobjects.com/projects/oca-12-migration-tickets/work_packages/22116/activity)

cc ~ @Eficent @hveficent 