### PR TITLE
[12.0][IMP] ao_base fix currency amount_to_text:  #22764

### DIFF
--- a/ao_base/README.rst
+++ b/ao_base/README.rst
@@ -12,6 +12,7 @@ This module contains customizations specific to Aleph Objects.
   deactivated (#12077).
 * In contact, fill Country field when setting the state first.
 * Security group Global Filter Management allow to unlink Global Filters
+* Corrects the function amount_to_text removing unnecessary "and"s
 
 Credits
 =======

--- a/ao_base/models/__init__.py
+++ b/ao_base/models/__init__.py
@@ -1,2 +1,3 @@
+from . import res_currency
 from . import res_users
 from . import res_partner

--- a/ao_base/models/res_currency.py
+++ b/ao_base/models/res_currency.py
@@ -1,0 +1,14 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class Currency(models.Model):
+    _inherit = "res.currency"
+
+    @api.multi
+    def amount_to_text(self, amount):
+        res = super().amount_to_text(amount)
+        res = res.replace(' And', '')
+        return res


### PR DESCRIPTION
Fixes amount_to_text in order to remove unneccessary " And"s values. Related to [
#22764](https://projects.alephobjects.com/projects/oca-12-migration-tickets/work_packages/22764/activity)

cc ~ @Eficent