### PR TITLE
[12.0][ENH]do not restrict sales team in leads

### DIFF
--- a/ao_crm/models/crm_lead.py
+++ b/ao_crm/models/crm_lead.py
@@ -87,3 +87,11 @@ class Lead(models.Model):
             kwargs['body'] = mail.html_sanitize(kwargs.get('body'))
         return super(Lead, self).message_post_with_template(
             template_id, **kwargs)
+
+    @api.constrains('user_id')
+    @api.multi
+    def _valid_team(self):
+        # Odoo will change the team to the default overwriting what the user
+        # puts (_valid_team method). That is not good. If the team is wrong
+        # a constraint will do the thing
+        return True


### PR DESCRIPTION
Basically, standard odoo calls the onchange from the constraint and taht way we cannot put a different sales team than the salesperson. We don't want that so we overpass the constraint.

Solves #22542