### PR TITLE
[12.0][UPT]do not set a default bank account on the invoice

### DIFF
--- a/ao_account/models/account_invoice.py
+++ b/ao_account/models/account_invoice.py
@@ -19,3 +19,7 @@ class AccountInvoice(models.Model):
         return super(
             AccountInvoice, self.with_context(
                 mail_auto_subscribe_no_notify=True)).write(vals)
+
+    def _get_partner_bank_id(self, company_id):
+        super(AccountInvoice, self)._get_partner_bank_id(company_id)
+        return False


### PR DESCRIPTION
Fixes #22570

Basically, we don't need a dummy default value for the bank account in the invoice. Odoo is just setting as default the first one, that is not necessary and it is confusing. Bank Account is just info for the partner, leaving it empty is not big deal.