### PR TITLE
[12.0][FIX] ao_purchase_auto_close tests

### DIFF
--- a/ao_purchase_auto_close/models/purchase_order.py
+++ b/ao_purchase_auto_close/models/purchase_order.py
@@ -17,7 +17,6 @@ class PurchaseOrder(models.Model):
             ("invoice_status", "=", "invoiced"),
             ("pending_qty_to_invoice", "=", False),
             ("pending_qty_to_receive", "=", False),
-            ("unreconciled", "=", False),
         ]
 
     @api.model

--- a/ao_purchase_auto_close/tests/test_ao_purchase_auto_close.py
+++ b/ao_purchase_auto_close/tests/test_ao_purchase_auto_close.py
@@ -41,7 +41,7 @@ class TestAutoClosePo(common.SavepointCase):
     def _do_picking(self, picking, date):
         """Do picking with only one move on the given date."""
         picking.action_confirm()
-        picking.force_assign()
+        picking.action_assign()
         picking.move_lines.quantity_done = picking.move_lines.product_uom_qty
         picking.action_done()
         for move in picking.move_lines:

--- a/ao_sale/views/sale_view.xml
+++ b/ao_sale/views/sale_view.xml
@@ -167,7 +167,7 @@
                         <label for="product_uom_qty"/>
                         <div>
                             <field name="product_uom_qty" readonly="1" class="oe_inline"/>
-                            <field name="product_uom" groups="product.group_uom" class="oe_inline"/>
+                            <field name="product_uom" groups="uom.group_uom" class="oe_inline"/>
                         </div>
                     </group>
                     <group>


### PR DESCRIPTION
Quick fix! Replace non-existing method `force_assign()` to `action_assign()`

cc ~ @Eficent @hveficent 